### PR TITLE
Add reset values and access modifiers from the SDK

### DIFF
--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -11804,6 +11804,8 @@
 						<name>cci_cfg</name>
 						<description>cci_cfg.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x00000221</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_mcci_clk_inv</name>
@@ -11856,6 +11858,8 @@
 						<name>cci_addr</name>
 						<description>cci_addr.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>apb_cci_addr</name>
@@ -11868,6 +11872,8 @@
 						<name>cci_wdata</name>
 						<description>cci_wdata.</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>apb_cci_wdata</name>
@@ -11880,11 +11886,14 @@
 						<name>cci_rdata</name>
 						<description>cci_rdata.</description>
 						<addressOffset>0xC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>apb_cci_rdata</name>
 								<lsb>0</lsb>
 								<msb>31</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -11892,21 +11901,26 @@
 						<name>cci_ctl</name>
 						<description>cci_ctl.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ahb_state</name>
 								<lsb>2</lsb>
 								<msb>3</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>cci_read_flag</name>
 								<lsb>1</lsb>
 								<msb>1</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>cci_write_flag</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -12697,6 +12697,8 @@
 						<name>utx_config</name>
 						<description>utx_config.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x00001700</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_utx_len</name>
@@ -12754,6 +12756,8 @@
 						<name>urx_config</name>
 						<description>urx_config.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x00000700</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_urx_len</name>
@@ -12821,6 +12825,8 @@
 						<name>uart_bit_prd</name>
 						<description>uart_bit_prd.</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0x00ff00ff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_urx_bit_prd</name>
@@ -12838,6 +12844,8 @@
 						<name>data_config</name>
 						<description>data_config.</description>
 						<addressOffset>0xC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_uart_bit_inv</name>
@@ -12850,6 +12858,8 @@
 						<name>utx_ir_position</name>
 						<description>utx_ir_position.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x009f0070</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_utx_ir_pos_p</name>
@@ -12867,6 +12877,8 @@
 						<name>urx_ir_position</name>
 						<description>urx_ir_position.</description>
 						<addressOffset>0x14</addressOffset>
+						<resetValue>0x0000006f</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_urx_ir_pos_s</name>
@@ -12879,6 +12891,8 @@
 						<name>urx_rto_timer</name>
 						<description>urx_rto_timer.</description>
 						<addressOffset>0x18</addressOffset>
+						<resetValue>0x0000000f</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_urx_rto_value</name>
@@ -12891,6 +12905,9 @@
 						<name>uart_int_sts</name>
 						<description>UART interrupt status</description>
 						<addressOffset>0x20</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>urx_fer_int</name>
@@ -12938,6 +12955,8 @@
 						<name>uart_int_mask</name>
 						<description>UART interrupt mask</description>
 						<addressOffset>0x24</addressOffset>
+						<resetValue>0x000000ff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_urx_fer_mask</name>
@@ -12985,6 +13004,8 @@
 						<name>uart_int_clear</name>
 						<description>UART interrupt clear</description>
 						<addressOffset>0x28</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rsvd_7</name>
@@ -13032,6 +13053,8 @@
 						<name>uart_int_en</name>
 						<description>UART interrupt enable</description>
 						<addressOffset>0x2C</addressOffset>
+						<resetValue>0x000000ff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_urx_fer_en</name>
@@ -13079,6 +13102,9 @@
 						<name>uart_status</name>
 						<description>uart_status.</description>
 						<addressOffset>0x30</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>sts_urx_bus_busy</name>
@@ -13096,6 +13122,9 @@
 						<name>sts_urx_abr_prd</name>
 						<description>sts_urx_abr_prd.</description>
 						<addressOffset>0x34</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>sts_urx_abr_prd_0x55</name>
@@ -13113,6 +13142,8 @@
 						<name>uart_fifo_config_0</name>
 						<description>uart_fifo_config_0.</description>
 						<addressOffset>0x80</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rx_fifo_underflow</name>
@@ -13164,6 +13195,8 @@
 						<name>uart_fifo_config_1</name>
 						<description>uart_fifo_config_1.</description>
 						<addressOffset>0x84</addressOffset>
+						<resetValue>0x00000020</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rx_fifo_th</name>
@@ -13179,11 +13212,13 @@
 								<name>rx_fifo_cnt</name>
 								<lsb>8</lsb>
 								<msb>13</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>tx_fifo_cnt</name>
 								<lsb>0</lsb>
 								<msb>5</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -13191,6 +13226,9 @@
 						<name>uart_fifo_wdata</name>
 						<description>uart_fifo_wdata.</description>
 						<addressOffset>0x88</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>write-only</access>
 						<fields>
 							<field>
 								<name>uart_fifo_wdata</name>
@@ -13203,6 +13241,9 @@
 						<name>uart_fifo_rdata</name>
 						<description>uart_fifo_rdata.</description>
 						<addressOffset>0x8C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>uart_fifo_rdata</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -8181,6 +8181,8 @@
 						<name>gpadc_config</name>
 						<description>gpadc_config.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rsvd_31_24</name>
@@ -8196,6 +8198,7 @@
 								<name>gpadc_fifo_data_count</name>
 								<lsb>16</lsb>
 								<msb>21</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>gpadc_fifo_underrun_mask</name>
@@ -8231,26 +8234,31 @@
 								<name>gpadc_fifo_underrun</name>
 								<lsb>6</lsb>
 								<msb>6</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>gpadc_fifo_overrun</name>
 								<lsb>5</lsb>
 								<msb>5</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>gpadc_rdy</name>
 								<lsb>4</lsb>
 								<msb>4</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>gpadc_fifo_full</name>
 								<lsb>3</lsb>
 								<msb>3</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>gpadc_fifo_ne</name>
 								<lsb>2</lsb>
 								<msb>2</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>gpadc_fifo_clr</name>
@@ -8268,6 +8276,9 @@
 						<name>gpadc_dma_rdata</name>
 						<description>gpadc_dma_rdata.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>rsvd_31_26</name>
@@ -8285,6 +8296,8 @@
 						<name>gpdac_config</name>
 						<description>gpdac_config.</description>
 						<addressOffset>0x40</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rsvd_31_24</name>
@@ -8327,6 +8340,8 @@
 						<name>gpdac_dma_config</name>
 						<description>gpdac_dma_config.</description>
 						<addressOffset>0x44</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpdac_dma_format</name>
@@ -8344,6 +8359,9 @@
 						<name>gpdac_dma_wdata</name>
 						<description>gpdac_dma_wdata.</description>
 						<addressOffset>0x48</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>write-only</access>
 						<fields>
 							<field>
 								<name>gpdac_dma_wdata</name>
@@ -8356,6 +8374,9 @@
 						<name>gpdac_tx_fifo_status</name>
 						<description>gpdac_tx_fifo_status.</description>
 						<addressOffset>0x4C</addressOffset>
+						<resetValue>0x00000040</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>TxFifoWrPtr</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -8587,6 +8587,8 @@
 						<name>se_sha_0_ctrl</name>
 						<description>se_sha_0_ctrl.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_sha_0_msg_len</name>
@@ -8617,6 +8619,7 @@
 								<name>se_sha_0_int</name>
 								<lsb>8</lsb>
 								<msb>8</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>se_sha_0_hash_sel</name>
@@ -8642,6 +8645,7 @@
 								<name>se_sha_0_busy</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -8649,6 +8653,8 @@
 						<name>se_sha_0_msa</name>
 						<description>se_sha_0_msa.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_sha_0_msa</name>
@@ -8661,6 +8667,9 @@
 						<name>se_sha_0_status</name>
 						<description>se_sha_0_status.</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0x00000041</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_status</name>
@@ -8673,6 +8682,8 @@
 						<name>se_sha_0_endian</name>
 						<description>se_sha_0_endian.</description>
 						<addressOffset>0xC</addressOffset>
+						<resetValue>0x00000001</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_sha_0_dout_endian</name>
@@ -8685,6 +8696,9 @@
 						<name>se_sha_0_hash_l_0</name>
 						<description>se_sha_0_hash_l_0.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_l_0</name>
@@ -8697,6 +8711,9 @@
 						<name>se_sha_0_hash_l_1</name>
 						<description>se_sha_0_hash_l_1.</description>
 						<addressOffset>0x14</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_l_1</name>
@@ -8709,6 +8726,9 @@
 						<name>se_sha_0_hash_l_2</name>
 						<description>se_sha_0_hash_l_2.</description>
 						<addressOffset>0x18</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_l_2</name>
@@ -8721,6 +8741,9 @@
 						<name>se_sha_0_hash_l_3</name>
 						<description>se_sha_0_hash_l_3.</description>
 						<addressOffset>0x1C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_l_3</name>
@@ -8733,6 +8756,9 @@
 						<name>se_sha_0_hash_l_4</name>
 						<description>se_sha_0_hash_l_4.</description>
 						<addressOffset>0x20</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_l_4</name>
@@ -8745,6 +8771,9 @@
 						<name>se_sha_0_hash_l_5</name>
 						<description>se_sha_0_hash_l_5.</description>
 						<addressOffset>0x24</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_l_5</name>
@@ -8757,6 +8786,9 @@
 						<name>se_sha_0_hash_l_6</name>
 						<description>se_sha_0_hash_l_6.</description>
 						<addressOffset>0x28</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_l_6</name>
@@ -8769,6 +8801,9 @@
 						<name>se_sha_0_hash_l_7</name>
 						<description>se_sha_0_hash_l_7.</description>
 						<addressOffset>0x2C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_l_7</name>
@@ -8781,6 +8816,9 @@
 						<name>se_sha_0_hash_h_0</name>
 						<description>se_sha_0_hash_h_0.</description>
 						<addressOffset>0x30</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_h_0</name>
@@ -8793,6 +8831,9 @@
 						<name>se_sha_0_hash_h_1</name>
 						<description>se_sha_0_hash_h_1.</description>
 						<addressOffset>0x34</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_h_1</name>
@@ -8805,6 +8846,9 @@
 						<name>se_sha_0_hash_h_2</name>
 						<description>se_sha_0_hash_h_2.</description>
 						<addressOffset>0x38</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_h_2</name>
@@ -8817,6 +8861,9 @@
 						<name>se_sha_0_hash_h_3</name>
 						<description>se_sha_0_hash_h_3.</description>
 						<addressOffset>0x3C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_h_3</name>
@@ -8829,6 +8876,9 @@
 						<name>se_sha_0_hash_h_4</name>
 						<description>se_sha_0_hash_h_4.</description>
 						<addressOffset>0x40</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_h_4</name>
@@ -8841,6 +8891,9 @@
 						<name>se_sha_0_hash_h_5</name>
 						<description>se_sha_0_hash_h_5.</description>
 						<addressOffset>0x44</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_h_5</name>
@@ -8853,6 +8906,9 @@
 						<name>se_sha_0_hash_h_6</name>
 						<description>se_sha_0_hash_h_6.</description>
 						<addressOffset>0x48</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_h_6</name>
@@ -8865,6 +8921,9 @@
 						<name>se_sha_0_hash_h_7</name>
 						<description>se_sha_0_hash_h_7.</description>
 						<addressOffset>0x4C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_sha_0_hash_h_7</name>
@@ -8877,6 +8936,8 @@
 						<name>se_sha_0_link</name>
 						<description>se_sha_0_link.</description>
 						<addressOffset>0x50</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_sha_0_lca</name>
@@ -8889,6 +8950,8 @@
 						<name>se_sha_0_ctrl_prot</name>
 						<description>se_sha_0_ctrl_prot.</description>
 						<addressOffset>0xFC</addressOffset>
+						<resetValue>0x00000007</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_sha_id1_en</name>
@@ -8911,6 +8974,8 @@
 						<name>se_aes_0_ctrl</name>
 						<description>se_aes_0_ctrl.</description>
 						<addressOffset>0x100</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_msg_len</name>
@@ -8951,6 +9016,7 @@
 								<name>se_aes_0_int</name>
 								<lsb>8</lsb>
 								<msb>8</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>se_aes_0_hw_key_en</name>
@@ -8986,6 +9052,7 @@
 								<name>se_aes_0_busy</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -8993,6 +9060,8 @@
 						<name>se_aes_0_msa</name>
 						<description>se_aes_0_msa.</description>
 						<addressOffset>0x104</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_msa</name>
@@ -9005,6 +9074,8 @@
 						<name>se_aes_0_mda</name>
 						<description>se_aes_0_mda.</description>
 						<addressOffset>0x108</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_mda</name>
@@ -9017,6 +9088,9 @@
 						<name>se_aes_0_status</name>
 						<description>se_aes_0_status.</description>
 						<addressOffset>0x10C</addressOffset>
+						<resetValue>0x00000100</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_aes_0_status</name>
@@ -9029,6 +9103,8 @@
 						<name>se_aes_0_iv_0</name>
 						<description>se_aes_0_iv_0.</description>
 						<addressOffset>0x110</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_iv_0</name>
@@ -9041,6 +9117,8 @@
 						<name>se_aes_0_iv_1</name>
 						<description>se_aes_0_iv_1.</description>
 						<addressOffset>0x114</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_iv_1</name>
@@ -9053,6 +9131,8 @@
 						<name>se_aes_0_iv_2</name>
 						<description>se_aes_0_iv_2.</description>
 						<addressOffset>0x118</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_iv_2</name>
@@ -9065,6 +9145,8 @@
 						<name>se_aes_0_iv_3</name>
 						<description>se_aes_0_iv_3.</description>
 						<addressOffset>0x11C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_iv_3</name>
@@ -9077,6 +9159,8 @@
 						<name>se_aes_0_key_0</name>
 						<description>se_aes_0_key_0.</description>
 						<addressOffset>0x120</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_key_0</name>
@@ -9089,6 +9173,8 @@
 						<name>se_aes_0_key_1</name>
 						<description>se_aes_0_key_1.</description>
 						<addressOffset>0x124</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_key_1</name>
@@ -9101,6 +9187,8 @@
 						<name>se_aes_0_key_2</name>
 						<description>se_aes_0_key_2.</description>
 						<addressOffset>0x128</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_key_2</name>
@@ -9113,6 +9201,8 @@
 						<name>se_aes_0_key_3</name>
 						<description>se_aes_0_key_3.</description>
 						<addressOffset>0x12C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_key_3</name>
@@ -9125,6 +9215,8 @@
 						<name>se_aes_0_key_4</name>
 						<description>se_aes_0_key_4.</description>
 						<addressOffset>0x130</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_key_4</name>
@@ -9137,6 +9229,8 @@
 						<name>se_aes_0_key_5</name>
 						<description>se_aes_0_key_5.</description>
 						<addressOffset>0x134</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_key_5</name>
@@ -9149,6 +9243,8 @@
 						<name>se_aes_0_key_6</name>
 						<description>se_aes_0_key_6.</description>
 						<addressOffset>0x138</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_key_6</name>
@@ -9161,6 +9257,8 @@
 						<name>se_aes_0_key_7</name>
 						<description>se_aes_0_key_7.</description>
 						<addressOffset>0x13C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_key_7</name>
@@ -9173,6 +9271,8 @@
 						<name>se_aes_0_key_sel_0</name>
 						<description>se_aes_0_key_sel_0.</description>
 						<addressOffset>0x140</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_key_sel_0</name>
@@ -9185,6 +9285,8 @@
 						<name>se_aes_0_key_sel_1</name>
 						<description>se_aes_0_key_sel_1.</description>
 						<addressOffset>0x144</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_key_sel_1</name>
@@ -9197,6 +9299,8 @@
 						<name>se_aes_0_endian</name>
 						<description>se_aes_0_endian.</description>
 						<addressOffset>0x148</addressOffset>
+						<resetValue>0x0000000f</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_ctr_len</name>
@@ -9229,6 +9333,8 @@
 						<name>se_aes_0_sboot</name>
 						<description>se_aes_0_sboot.</description>
 						<addressOffset>0x14C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_sboot_key_sel</name>
@@ -9241,6 +9347,8 @@
 						<name>se_aes_0_link</name>
 						<description>se_aes_0_link.</description>
 						<addressOffset>0x150</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_0_lca</name>
@@ -9253,6 +9361,8 @@
 						<name>se_aes_0_ctrl_prot</name>
 						<description>se_aes_0_ctrl_prot.</description>
 						<addressOffset>0x1FC</addressOffset>
+						<resetValue>0x00000007</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_aes_id1_en</name>
@@ -9275,6 +9385,8 @@
 						<name>se_trng_0_ctrl_0</name>
 						<description>se_trng_0_ctrl_0.</description>
 						<addressOffset>0x200</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_trng_0_manual_en</name>
@@ -9310,11 +9422,13 @@
 								<name>se_trng_0_int</name>
 								<lsb>8</lsb>
 								<msb>8</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>se_trng_0_ht_error</name>
 								<lsb>4</lsb>
 								<msb>4</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>se_trng_0_dout_clr_1t</name>
@@ -9335,6 +9449,7 @@
 								<name>se_trng_0_busy</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -9342,6 +9457,9 @@
 						<name>se_trng_0_status</name>
 						<description>se_trng_0_status.</description>
 						<addressOffset>0x204</addressOffset>
+						<resetValue>0x00100020</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_trng_0_status</name>
@@ -9354,6 +9472,9 @@
 						<name>se_trng_0_dout_0</name>
 						<description>se_trng_0_dout_0.</description>
 						<addressOffset>0x208</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_trng_0_dout_0</name>
@@ -9366,6 +9487,9 @@
 						<name>se_trng_0_dout_1</name>
 						<description>se_trng_0_dout_1.</description>
 						<addressOffset>0x20C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_trng_0_dout_1</name>
@@ -9378,6 +9502,9 @@
 						<name>se_trng_0_dout_2</name>
 						<description>se_trng_0_dout_2.</description>
 						<addressOffset>0x210</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_trng_0_dout_2</name>
@@ -9390,6 +9517,9 @@
 						<name>se_trng_0_dout_3</name>
 						<description>se_trng_0_dout_3.</description>
 						<addressOffset>0x214</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_trng_0_dout_3</name>
@@ -9402,6 +9532,9 @@
 						<name>se_trng_0_dout_4</name>
 						<description>se_trng_0_dout_4.</description>
 						<addressOffset>0x218</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_trng_0_dout_4</name>
@@ -9414,6 +9547,9 @@
 						<name>se_trng_0_dout_5</name>
 						<description>se_trng_0_dout_5.</description>
 						<addressOffset>0x21C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_trng_0_dout_5</name>
@@ -9426,6 +9562,9 @@
 						<name>se_trng_0_dout_6</name>
 						<description>se_trng_0_dout_6.</description>
 						<addressOffset>0x220</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_trng_0_dout_6</name>
@@ -9438,6 +9577,9 @@
 						<name>se_trng_0_dout_7</name>
 						<description>se_trng_0_dout_7.</description>
 						<addressOffset>0x224</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_trng_0_dout_7</name>
@@ -9450,6 +9592,8 @@
 						<name>se_trng_0_test</name>
 						<description>se_trng_0_test.</description>
 						<addressOffset>0x228</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_trng_0_ht_alarm_n</name>
@@ -9482,6 +9626,8 @@
 						<name>se_trng_0_ctrl_1</name>
 						<description>se_trng_0_ctrl_1.</description>
 						<addressOffset>0x22C</addressOffset>
+						<resetValue>0x0000ffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_trng_0_reseed_n_lsb</name>
@@ -9494,6 +9640,8 @@
 						<name>se_trng_0_ctrl_2</name>
 						<description>se_trng_0_ctrl_2.</description>
 						<addressOffset>0x230</addressOffset>
+						<resetValue>0x000000ff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_trng_0_reseed_n_msb</name>
@@ -9506,6 +9654,8 @@
 						<name>se_trng_0_ctrl_3</name>
 						<description>se_trng_0_ctrl_3.</description>
 						<addressOffset>0x234</addressOffset>
+						<resetValue>0x837a4203</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_trng_0_rosc_en</name>
@@ -9538,6 +9688,9 @@
 						<name>se_trng_0_test_out_0</name>
 						<description>se_trng_0_test_out_0.</description>
 						<addressOffset>0x240</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_trng_0_test_out_0</name>
@@ -9550,6 +9703,9 @@
 						<name>se_trng_0_test_out_1</name>
 						<description>se_trng_0_test_out_1.</description>
 						<addressOffset>0x244</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_trng_0_test_out_1</name>
@@ -9562,6 +9718,9 @@
 						<name>se_trng_0_test_out_2</name>
 						<description>se_trng_0_test_out_2.</description>
 						<addressOffset>0x248</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_trng_0_test_out_2</name>
@@ -9574,6 +9733,9 @@
 						<name>se_trng_0_test_out_3</name>
 						<description>se_trng_0_test_out_3.</description>
 						<addressOffset>0x24C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_trng_0_test_out_3</name>
@@ -9586,6 +9748,8 @@
 						<name>se_trng_0_ctrl_prot</name>
 						<description>se_trng_0_ctrl_prot.</description>
 						<addressOffset>0x2FC</addressOffset>
+						<resetValue>0x00000007</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_trng_id1_en</name>
@@ -9608,11 +9772,14 @@
 						<name>se_pka_0_ctrl_0</name>
 						<description>se_pka_0_ctrl_0.</description>
 						<addressOffset>0x300</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_pka_0_status</name>
 								<lsb>17</lsb>
 								<msb>31</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>se_pka_0_status_clr_1t</name>
@@ -9648,6 +9815,7 @@
 								<name>se_pka_0_int</name>
 								<lsb>8</lsb>
 								<msb>8</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>se_pka_0_prot_md</name>
@@ -9663,6 +9831,7 @@
 								<name>se_pka_0_busy</name>
 								<lsb>2</lsb>
 								<msb>2</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>se_pka_0_done_clr_1t</name>
@@ -9673,6 +9842,7 @@
 								<name>se_pka_0_done</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -9680,6 +9850,8 @@
 						<name>se_pka_0_seed</name>
 						<description>se_pka_0_seed.</description>
 						<addressOffset>0x30C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_pka_0_seed</name>
@@ -9692,6 +9864,8 @@
 						<name>se_pka_0_ctrl_1</name>
 						<description>se_pka_0_ctrl_1.</description>
 						<addressOffset>0x310</addressOffset>
+						<resetValue>0x00000005</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_pka_0_hbypass</name>
@@ -9709,18 +9883,24 @@
 						<name>se_pka_0_rw</name>
 						<description>se_pka_0_rw.</description>
 						<addressOffset>0x340</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>se_pka_0_rw_burst</name>
 						<description>se_pka_0_rw_burst.</description>
 						<addressOffset>0x360</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>se_pka_0_ctrl_prot</name>
 						<description>se_pka_0_ctrl_prot.</description>
 						<addressOffset>0x3FC</addressOffset>
+						<resetValue>0x00000007</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_pka_id1_en</name>
@@ -9743,6 +9923,8 @@
 						<name>se_cdet_0_ctrl_0</name>
 						<description>se_cdet_0_ctrl_0.</description>
 						<addressOffset>0x400</addressOffset>
+						<resetValue>0x21640004</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_cdet_0_g_loop_min</name>
@@ -9758,11 +9940,13 @@
 								<name>se_cdet_0_status</name>
 								<lsb>2</lsb>
 								<msb>15</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>se_cdet_0_error</name>
 								<lsb>1</lsb>
 								<msb>1</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>se_cdet_0_en</name>
@@ -9775,6 +9959,8 @@
 						<name>se_cdet_0_ctrl_1</name>
 						<description>se_cdet_0_ctrl_1.</description>
 						<addressOffset>0x404</addressOffset>
+						<resetValue>0x00ff0332</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_cdet_0_g_slp_n</name>
@@ -9797,6 +9983,8 @@
 						<name>se_cdet_0_ctrl_prot</name>
 						<description>se_cdet_0_ctrl_prot.</description>
 						<addressOffset>0x4FC</addressOffset>
+						<resetValue>0x00000007</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_cdet_id1_en</name>
@@ -9819,6 +10007,8 @@
 						<name>se_gmac_0_ctrl_0</name>
 						<description>se_gmac_0_ctrl_0.</description>
 						<addressOffset>0x500</addressOffset>
+						<resetValue>0x00007000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_gmac_0_x_endian</name>
@@ -9854,6 +10044,7 @@
 								<name>se_gmac_0_int</name>
 								<lsb>8</lsb>
 								<msb>8</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>se_gmac_0_en</name>
@@ -9869,6 +10060,7 @@
 								<name>se_gmac_0_busy</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -9876,6 +10068,8 @@
 						<name>se_gmac_0_lca</name>
 						<description>se_gmac_0_lca.</description>
 						<addressOffset>0x504</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_gmac_0_lca</name>
@@ -9888,6 +10082,9 @@
 						<name>se_gmac_0_status</name>
 						<description>se_gmac_0_status.</description>
 						<addressOffset>0x508</addressOffset>
+						<resetValue>0xf1000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_gmac_0_status</name>
@@ -9900,6 +10097,8 @@
 						<name>se_gmac_0_ctrl_prot</name>
 						<description>se_gmac_0_ctrl_prot.</description>
 						<addressOffset>0x5FC</addressOffset>
+						<resetValue>0x00000007</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>se_gmac_id1_en</name>
@@ -9922,6 +10121,9 @@
 						<name>se_ctrl_prot_rd</name>
 						<description>se_ctrl_prot_rd.</description>
 						<addressOffset>0xF00</addressOffset>
+						<resetValue>0x00777777</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>se_dbg_dis</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -12212,6 +12212,8 @@
 						<name>l1c_config</name>
 						<description>l1c_config.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x06000f00</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>wrap_dis</name>
@@ -12262,6 +12264,7 @@
 								<name>l1c_invalid_done</name>
 								<lsb>3</lsb>
 								<msb>3</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>l1c_invalid_en</name>
@@ -12284,6 +12287,9 @@
 						<name>hit_cnt_lsb</name>
 						<description>hit_cnt_lsb.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>hit_cnt_lsb</name>
@@ -12296,6 +12302,9 @@
 						<name>hit_cnt_msb</name>
 						<description>hit_cnt_msb.</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>hit_cnt_msb</name>
@@ -12308,6 +12317,9 @@
 						<name>miss_cnt</name>
 						<description>miss_cnt.</description>
 						<addressOffset>0xC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>miss_cnt</name>
@@ -12320,12 +12332,16 @@
 						<name>l1c_range</name>
 						<description>l1c_range.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>l1c_bmx_err_addr_en</name>
 						<description>l1c_bmx_err_addr_en.</description>
 						<addressOffset>0x200</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>l1c_hsel_option</name>
@@ -12336,11 +12352,13 @@
 								<name>l1c_bmx_err_tz</name>
 								<lsb>5</lsb>
 								<msb>5</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>l1c_bmx_err_dec</name>
 								<lsb>4</lsb>
 								<msb>4</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>l1c_bmx_err_addr_dis</name>
@@ -12353,6 +12371,9 @@
 						<name>l1c_bmx_err_addr</name>
 						<description>l1c_bmx_err_addr.</description>
 						<addressOffset>0x204</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>l1c_bmx_err_addr</name>
@@ -12365,6 +12386,9 @@
 						<name>irom1_misr_dataout_0</name>
 						<description>irom1_misr_dataout_0.</description>
 						<addressOffset>0x208</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>irom1_misr_dataout_0</name>
@@ -12377,12 +12401,16 @@
 						<name>irom1_misr_dataout_1</name>
 						<description>irom1_misr_dataout_1.</description>
 						<addressOffset>0x20C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>cpu_clk_gate</name>
 						<description>cpu_clk_gate.</description>
 						<addressOffset>0x210</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>force_e21_clock_on_2</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -10291,6 +10291,8 @@
 						<name>ef_cfg_0</name>
 						<description>ef_cfg_0.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_dbg_mode</name>
@@ -10398,6 +10400,8 @@
 						<name>ef_dbg_pwd_low</name>
 						<description>ef_dbg_pwd_low.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_dbg_pwd_low</name>
@@ -10410,6 +10414,8 @@
 						<name>ef_dbg_pwd_high</name>
 						<description>ef_dbg_pwd_high.</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_dbg_pwd_high</name>
@@ -10422,6 +10428,8 @@
 						<name>ef_ana_trim_0</name>
 						<description>ef_ana_trim_0.</description>
 						<addressOffset>0xC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_ana_trim_0</name>
@@ -10434,6 +10442,8 @@
 						<name>ef_sw_usage_0</name>
 						<description>ef_sw_usage_0.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_sw_usage_0</name>
@@ -10446,6 +10456,8 @@
 						<name>ef_wifi_mac_low</name>
 						<description>ef_wifi_mac_low.</description>
 						<addressOffset>0x14</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_wifi_mac_low</name>
@@ -10458,6 +10470,8 @@
 						<name>ef_wifi_mac_high</name>
 						<description>ef_wifi_mac_high.</description>
 						<addressOffset>0x18</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_wifi_mac_high</name>
@@ -10470,6 +10484,8 @@
 						<name>ef_key_slot_0_w0</name>
 						<description>ef_key_slot_0_w0.</description>
 						<addressOffset>0x1C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_0_w0</name>
@@ -10482,6 +10498,8 @@
 						<name>ef_key_slot_0_w1</name>
 						<description>ef_key_slot_0_w1.</description>
 						<addressOffset>0x20</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_0_w1</name>
@@ -10494,6 +10512,8 @@
 						<name>ef_key_slot_0_w2</name>
 						<description>ef_key_slot_0_w2.</description>
 						<addressOffset>0x24</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_0_w2</name>
@@ -10506,6 +10526,8 @@
 						<name>ef_key_slot_0_w3</name>
 						<description>ef_key_slot_0_w3.</description>
 						<addressOffset>0x28</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_0_w3</name>
@@ -10518,6 +10540,8 @@
 						<name>ef_key_slot_1_w0</name>
 						<description>ef_key_slot_1_w0.</description>
 						<addressOffset>0x2C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_1_w0</name>
@@ -10530,6 +10554,8 @@
 						<name>ef_key_slot_1_w1</name>
 						<description>ef_key_slot_1_w1.</description>
 						<addressOffset>0x30</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_1_w1</name>
@@ -10542,6 +10568,8 @@
 						<name>ef_key_slot_1_w2</name>
 						<description>ef_key_slot_1_w2.</description>
 						<addressOffset>0x34</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_1_w2</name>
@@ -10554,6 +10582,8 @@
 						<name>ef_key_slot_1_w3</name>
 						<description>ef_key_slot_1_w3.</description>
 						<addressOffset>0x38</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_1_w3</name>
@@ -10566,6 +10596,8 @@
 						<name>ef_key_slot_2_w0</name>
 						<description>ef_key_slot_2_w0.</description>
 						<addressOffset>0x3C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_2_w0</name>
@@ -10578,6 +10610,8 @@
 						<name>ef_key_slot_2_w1</name>
 						<description>ef_key_slot_2_w1.</description>
 						<addressOffset>0x40</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_2_w1</name>
@@ -10590,6 +10624,8 @@
 						<name>ef_key_slot_2_w2</name>
 						<description>ef_key_slot_2_w2.</description>
 						<addressOffset>0x44</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_2_w2</name>
@@ -10602,6 +10638,8 @@
 						<name>ef_key_slot_2_w3</name>
 						<description>ef_key_slot_2_w3.</description>
 						<addressOffset>0x48</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_2_w3</name>
@@ -10614,6 +10652,8 @@
 						<name>ef_key_slot_3_w0</name>
 						<description>ef_key_slot_3_w0.</description>
 						<addressOffset>0x4C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_3_w0</name>
@@ -10626,6 +10666,8 @@
 						<name>ef_key_slot_3_w1</name>
 						<description>ef_key_slot_3_w1.</description>
 						<addressOffset>0x50</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_3_w1</name>
@@ -10638,6 +10680,8 @@
 						<name>ef_key_slot_3_w2</name>
 						<description>ef_key_slot_3_w2.</description>
 						<addressOffset>0x54</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_3_w2</name>
@@ -10650,6 +10694,8 @@
 						<name>ef_key_slot_3_w3</name>
 						<description>ef_key_slot_3_w3.</description>
 						<addressOffset>0x58</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_3_w3</name>
@@ -10662,6 +10708,8 @@
 						<name>ef_key_slot_4_w0</name>
 						<description>ef_key_slot_4_w0.</description>
 						<addressOffset>0x5C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_4_w0</name>
@@ -10674,6 +10722,8 @@
 						<name>ef_key_slot_4_w1</name>
 						<description>ef_key_slot_4_w1.</description>
 						<addressOffset>0x60</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_4_w1</name>
@@ -10686,6 +10736,8 @@
 						<name>ef_key_slot_4_w2</name>
 						<description>ef_key_slot_4_w2.</description>
 						<addressOffset>0x64</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_4_w2</name>
@@ -10698,6 +10750,8 @@
 						<name>ef_key_slot_4_w3</name>
 						<description>ef_key_slot_4_w3.</description>
 						<addressOffset>0x68</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_4_w3</name>
@@ -10710,6 +10764,8 @@
 						<name>ef_key_slot_5_w0</name>
 						<description>ef_key_slot_5_w0.</description>
 						<addressOffset>0x6C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_5_w0</name>
@@ -10722,6 +10778,8 @@
 						<name>ef_key_slot_5_w1</name>
 						<description>ef_key_slot_5_w1.</description>
 						<addressOffset>0x70</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_5_w1</name>
@@ -10734,6 +10792,8 @@
 						<name>ef_key_slot_5_w2</name>
 						<description>ef_key_slot_5_w2.</description>
 						<addressOffset>0x74</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_5_w2</name>
@@ -10746,6 +10806,8 @@
 						<name>ef_key_slot_5_w3</name>
 						<description>ef_key_slot_5_w3.</description>
 						<addressOffset>0x78</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_key_slot_5_w3</name>
@@ -10758,6 +10820,8 @@
 						<name>ef_data_0_lock</name>
 						<description>ef_data_0_lock.</description>
 						<addressOffset>0x7C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rd_lock_key_slot_5</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -32,6 +32,8 @@
 						<name>clk_cfg0</name>
 						<description>Clock configuration for processor and bus</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x6000000f</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>glb_id</name>
@@ -101,6 +103,8 @@
 						<name>clk_cfg1</name>
 						<description>clk_cfg1.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x01100001</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ble_en</name>
@@ -131,6 +135,8 @@
 						<name>clk_cfg2</name>
 						<description>Clock configuration for UART and Flash</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0xff8f2b17</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>dma_clk_en</name>
@@ -171,6 +177,7 @@
 								<name>hbn_uart_clk_sel</name>
 								<lsb>7</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>uart_clk_en</name>
@@ -188,6 +195,8 @@
 						<name>clk_cfg3</name>
 						<description>Clock configuration for I2C and SPI</description>
 						<addressOffset>0xC</addressOffset>
+						<resetValue>0x01ff0103</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>i2c_clk_en</name>
@@ -215,6 +224,8 @@
 						<name>swrst_cfg0</name>
 						<description>swrst_cfg0.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>swrst_s30</name>
@@ -242,6 +253,8 @@
 						<name>swrst_cfg1</name>
 						<description>swrst_cfg1.</description>
 						<addressOffset>0x14</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>swrst_s1a7</name>
@@ -369,6 +382,8 @@
 						<name>swrst_cfg2</name>
 						<description>swrst_cfg2.</description>
 						<addressOffset>0x18</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>pka_clk_sel</name>
@@ -401,12 +416,16 @@
 						<name>swrst_cfg3</name>
 						<description>swrst_cfg3.</description>
 						<addressOffset>0x1C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>cgen_cfg0</name>
 						<description>cgen_cfg0.</description>
 						<addressOffset>0x20</addressOffset>
+						<resetValue>0x000000ff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cgen_m</name>
@@ -419,6 +438,8 @@
 						<name>cgen_cfg1</name>
 						<description>cgen_cfg1.</description>
 						<addressOffset>0x24</addressOffset>
+						<resetValue>0x00ffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cgen_s1a</name>
@@ -436,6 +457,8 @@
 						<name>cgen_cfg2</name>
 						<description>cgen_cfg2.</description>
 						<addressOffset>0x28</addressOffset>
+						<resetValue>0x00000011</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cgen_s3</name>
@@ -453,12 +476,16 @@
 						<name>cgen_cfg3</name>
 						<description>cgen_cfg3.</description>
 						<addressOffset>0x2C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>MBIST_CTL</name>
 						<description>MBIST_CTL.</description>
 						<addressOffset>0x30</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_mbist_rst_n</name>
@@ -496,6 +523,9 @@
 						<name>MBIST_STAT</name>
 						<description>MBIST_STAT.</description>
 						<addressOffset>0x34</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>wifi_mbist_fail</name>
@@ -553,6 +583,8 @@
 						<name>bmx_cfg1</name>
 						<description>bmx_cfg1.</description>
 						<addressOffset>0x50</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>hbn_apb_cfg</name>
@@ -600,6 +632,8 @@
 						<name>bmx_cfg2</name>
 						<description>bmx_cfg2.</description>
 						<addressOffset>0x54</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>bmx_dbg_sel</name>
@@ -610,11 +644,13 @@
 								<name>bmx_err_tz</name>
 								<lsb>5</lsb>
 								<msb>5</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>bmx_err_dec</name>
 								<lsb>4</lsb>
 								<msb>4</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>bmx_err_addr_dis</name>
@@ -628,6 +664,9 @@
 						<name>bmx_err_addr</name>
 						<description>bmx_err_addr.</description>
 						<addressOffset>0x58</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>bmx_err_addr</name>
@@ -640,6 +679,9 @@
 						<name>bmx_dbg_out</name>
 						<description>bmx_dbg_out.</description>
 						<addressOffset>0x5C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>bmx_dbg_out</name>
@@ -700,6 +742,8 @@
 						<name>sram_ret</name>
 						<description>sram_ret.</description>
 						<addressOffset>0x70</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_sram_ret</name>
@@ -712,6 +756,8 @@
 						<name>sram_slp</name>
 						<description>sram_slp.</description>
 						<addressOffset>0x74</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_sram_slp</name>
@@ -724,6 +770,8 @@
 						<name>sram_parm</name>
 						<description>sram_parm.</description>
 						<addressOffset>0x78</addressOffset>
+						<resetValue>0x0c0c0c0c</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_sram_parm</name>
@@ -736,6 +784,8 @@
 						<name>seam_misc</name>
 						<description>seam_misc.</description>
 						<addressOffset>0x7C</addressOffset>
+						<resetValue>0x00000003</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>em_sel</name>
@@ -748,6 +798,8 @@
 						<name>glb_parm</name>
 						<description>glb_parm.</description>
 						<addressOffset>0x80</addressOffset>
+						<resetValue>0x00018300</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>uart_swap_set</name>
@@ -840,6 +892,8 @@
 						<name>CPU_CLK_CFG</name>
 						<description>CPU_CLK_CFG.</description>
 						<addressOffset>0x90</addressOffset>
+						<resetValue>0x00080010</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>debug_ndreset_gate</name>
@@ -867,6 +921,8 @@
 						<name>GPADC_32M_SRC_CTRL</name>
 						<description>Clock configuration for GPADC</description>
 						<addressOffset>0xA4</addressOffset>
+						<resetValue>0x00000102</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_32m_div_en</name>
@@ -889,6 +945,8 @@
 						<name>DIG32K_WAKEUP_CTRL</name>
 						<description>DIG32K_WAKEUP_CTRL.</description>
 						<addressOffset>0xA8</addressOffset>
+						<resetValue>0x033e13e8</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_en_platform_wakeup</name>
@@ -936,6 +994,8 @@
 						<name>WIFI_BT_COEX_CTRL</name>
 						<description>WIFI_BT_COEX_CTRL.</description>
 						<addressOffset>0xAC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>en_gpio_bt_coex</name>
@@ -963,6 +1023,8 @@
 						<name>UART_SIG_SEL_0</name>
 						<description>UART_SIG_SEL_0.</description>
 						<addressOffset>0xC0</addressOffset>
+						<resetValue>0x76543210</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>uart_sig_7_sel</name>
@@ -1010,6 +1072,8 @@
 						<name>DBG_SEL_LL</name>
 						<description>DBG_SEL_LL.</description>
 						<addressOffset>0xD0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_dbg_ll_ctrl</name>
@@ -1022,6 +1086,8 @@
 						<name>DBG_SEL_LH</name>
 						<description>DBG_SEL_LH.</description>
 						<addressOffset>0xD4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_dbg_lh_ctrl</name>
@@ -1034,6 +1100,8 @@
 						<name>DBG_SEL_HL</name>
 						<description>DBG_SEL_HL.</description>
 						<addressOffset>0xD8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_dbg_hl_ctrl</name>
@@ -1046,6 +1114,8 @@
 						<name>DBG_SEL_HH</name>
 						<description>DBG_SEL_HH.</description>
 						<addressOffset>0xDC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_dbg_hh_ctrl</name>
@@ -1058,6 +1128,9 @@
 						<name>debug</name>
 						<description>debug.</description>
 						<addressOffset>0xE0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>debug_i</name>
@@ -2506,6 +2579,8 @@
 						<name>led_driver</name>
 						<description>led_driver.</description>
 						<addressOffset>0x224</addressOffset>
+						<resetValue>0x00000080</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>pu_leddrv</name>
@@ -2543,6 +2618,8 @@
 						<name>gpdac_ctrl</name>
 						<description>gpdac_ctrl.</description>
 						<addressOffset>0x308</addressOffset>
+						<resetValue>0x00000003</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpdac_reserved</name>
@@ -2580,6 +2657,8 @@
 						<name>gpdac_actrl</name>
 						<description>gpdac_actrl.</description>
 						<addressOffset>0x30C</addressOffset>
+						<resetValue>0x000c0000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpdac_a_outmux</name>
@@ -2607,6 +2686,8 @@
 						<name>gpdac_bctrl</name>
 						<description>gpdac_bctrl.</description>
 						<addressOffset>0x310</addressOffset>
+						<resetValue>0x000c0000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpdac_b_outmux</name>
@@ -2634,6 +2715,8 @@
 						<name>gpdac_data</name>
 						<description>gpdac_data.</description>
 						<addressOffset>0x314</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpdac_a_data</name>
@@ -2651,6 +2734,9 @@
 						<name>tzc_glb_ctrl_0</name>
 						<description>tzc_glb_ctrl_0.</description>
 						<addressOffset>0xF00</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tzc_glb_clk_lock</name>
@@ -2728,6 +2814,9 @@
 						<name>tzc_glb_ctrl_1</name>
 						<description>tzc_glb_ctrl_1.</description>
 						<addressOffset>0xF04</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tzc_glb_swrst_s1f_lock</name>
@@ -2895,6 +2984,9 @@
 						<name>tzc_glb_ctrl_2</name>
 						<description>tzc_glb_ctrl_2.</description>
 						<addressOffset>0xF08</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tzc_glb_gpio_28_lock</name>
@@ -3045,9 +3137,8 @@
 					</register>
 					<register>
 						<name>tzc_glb_ctrl_3</name>
-						<description>tzc_glb_ctrl_3.</description>
+						<description>Reserved according to SDK.</description>
 						<addressOffset>0xF0C</addressOffset>
-						<fields/>
 					</register>
 				</registers>
 			</peripheral>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -11192,6 +11192,8 @@
 						<name>ef_if_ctrl_0</name>
 						<description>ef_if_ctrl_0.</description>
 						<addressOffset>0x800</addressOffset>
+						<resetValue>0x00240003</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_if_prot_code_cyc</name>
@@ -11212,6 +11214,7 @@
 								<name>ef_if_0_int</name>
 								<lsb>20</lsb>
 								<msb>20</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>ef_if_cyc_modify_lock</name>
@@ -11267,16 +11270,19 @@
 								<name>ef_if_0_busy</name>
 								<lsb>2</lsb>
 								<msb>2</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>ef_if_0_autoload_done</name>
 								<lsb>1</lsb>
 								<msb>1</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>ef_if_0_autoload_p1_done</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -11284,6 +11290,8 @@
 						<name>ef_if_cyc_0</name>
 						<description>ef_if_cyc_0.</description>
 						<addressOffset>0x804</addressOffset>
+						<resetValue>0x16000040</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_if_cyc_pd_cs_s</name>
@@ -11316,6 +11324,8 @@
 						<name>ef_if_cyc_1</name>
 						<description>ef_if_cyc_1.</description>
 						<addressOffset>0x808</addressOffset>
+						<resetValue>0x00206609</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_if_cyc_pd_cs_h</name>
@@ -11348,6 +11358,8 @@
 						<name>ef_if_0_manual</name>
 						<description>ef_if_0_manual.</description>
 						<addressOffset>0x80C</addressOffset>
+						<resetValue>0x0000e400</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_if_prot_code_manual</name>
@@ -11358,6 +11370,7 @@
 								<name>ef_if_0_q</name>
 								<lsb>16</lsb>
 								<msb>23</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>ef_if_csb</name>
@@ -11400,11 +11413,14 @@
 						<name>ef_if_0_status</name>
 						<description>ef_if_0_status.</description>
 						<addressOffset>0x810</addressOffset>
+						<resetValue>0x0000e400</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_if_0_status</name>
 								<lsb>0</lsb>
 								<msb>31</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -11412,6 +11428,9 @@
 						<name>ef_if_cfg_0</name>
 						<description>ef_if_cfg_0.</description>
 						<addressOffset>0x814</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>ef_if_dbg_mode</name>
@@ -11519,6 +11538,8 @@
 						<name>ef_sw_cfg_0</name>
 						<description>ef_sw_cfg_0.</description>
 						<addressOffset>0x818</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_sw_dbg_mode</name>
@@ -11633,11 +11654,14 @@
 						<name>ef_if_ana_trim_0</name>
 						<description>ef_if_ana_trim_0.</description>
 						<addressOffset>0x820</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_if_ana_trim_0</name>
 								<lsb>0</lsb>
 								<msb>31</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -11645,11 +11669,14 @@
 						<name>ef_if_sw_usage_0</name>
 						<description>ef_if_sw_usage_0.</description>
 						<addressOffset>0x824</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_if_sw_usage_0</name>
 								<lsb>0</lsb>
 								<msb>31</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -11657,6 +11684,8 @@
 						<name>ef_crc_ctrl_0</name>
 						<description>ef_crc_ctrl_0.</description>
 						<addressOffset>0xA00</addressOffset>
+						<resetValue>0x00ff0224</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_crc_slp_n</name>
@@ -11682,6 +11711,7 @@
 								<name>ef_crc_int</name>
 								<lsb>8</lsb>
 								<msb>8</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>ef_crc_din_endian</name>
@@ -11702,6 +11732,7 @@
 								<name>ef_crc_error</name>
 								<lsb>4</lsb>
 								<msb>4</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>ef_crc_mode</name>
@@ -11722,6 +11753,7 @@
 								<name>ef_crc_busy</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -11729,6 +11761,8 @@
 						<name>ef_crc_ctrl_1</name>
 						<description>ef_crc_ctrl_1.</description>
 						<addressOffset>0xA04</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_crc_data_0_en</name>
@@ -11741,6 +11775,8 @@
 						<name>ef_crc_ctrl_2</name>
 						<description>ef_crc_ctrl_2.</description>
 						<addressOffset>0xA08</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_crc_data_1_en</name>
@@ -11753,6 +11789,8 @@
 						<name>ef_crc_ctrl_3</name>
 						<description>ef_crc_ctrl_3.</description>
 						<addressOffset>0xA0C</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_crc_iv</name>
@@ -11765,6 +11803,8 @@
 						<name>ef_crc_ctrl_4</name>
 						<description>ef_crc_ctrl_4.</description>
 						<addressOffset>0xA10</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_crc_golden</name>
@@ -11777,11 +11817,14 @@
 						<name>ef_crc_ctrl_5</name>
 						<description>ef_crc_ctrl_5.</description>
 						<addressOffset>0xA14</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ef_crc_dout</name>
 								<lsb>0</lsb>
 								<msb>31</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -18018,6 +18018,8 @@
 						<name>PDS_CTL</name>
 						<description>PDS_CTL.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x1a006b00</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_pds_ctrl_pll</name>
@@ -18130,6 +18132,8 @@
 						<name>PDS_TIME1</name>
 						<description>PDS_TIME1.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x00000ca8</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_sleep_duration</name>
@@ -18142,6 +18146,8 @@
 						<name>PDS_INT</name>
 						<description>PDS_INT.</description>
 						<addressOffset>0xC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_pds_int_clr</name>
@@ -18172,21 +18178,25 @@
 								<name>ro_pds_pll_done_int</name>
 								<lsb>3</lsb>
 								<msb>3</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>ro_pds_rf_done_int</name>
 								<lsb>2</lsb>
 								<msb>2</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>ro_pds_irq_in</name>
 								<lsb>1</lsb>
 								<msb>1</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>ro_pds_wake_int</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -18194,6 +18204,8 @@
 						<name>PDS_CTL2</name>
 						<description>PDS_CTL2.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_pds_force_wb_gate_clk</name>
@@ -18251,6 +18263,8 @@
 						<name>PDS_CTL3</name>
 						<description>PDS_CTL3.</description>
 						<addressOffset>0x14</addressOffset>
+						<resetValue>0x49000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_pds_misc_iso_en</name>
@@ -18298,6 +18312,8 @@
 						<name>PDS_CTL4</name>
 						<description>PDS_CTL4.</description>
 						<addressOffset>0x18</addressOffset>
+						<resetValue>0x0f00f00f</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_pds_misc_gate_clk</name>
@@ -18365,6 +18381,9 @@
 						<name>pds_stat</name>
 						<description>pds_stat.</description>
 						<addressOffset>0x1C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>ro_pds_pll_state</name>
@@ -18387,6 +18406,8 @@
 						<name>pds_ram1</name>
 						<description>pds_ram1.</description>
 						<addressOffset>0x20</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_np_sram_pwr</name>
@@ -18399,6 +18420,8 @@
 						<name>rc32m_ctrl0</name>
 						<description>rc32m_ctrl0.</description>
 						<addressOffset>0x300</addressOffset>
+						<resetValue>0x18080018</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rc32m_code_fr_ext</name>
@@ -18434,11 +18457,13 @@
 								<name>rc32m_dig_code_fr_cal</name>
 								<lsb>6</lsb>
 								<msb>13</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rc32m_cal_precharge</name>
 								<lsb>5</lsb>
 								<msb>5</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rc32m_cal_div</name>
@@ -18449,16 +18474,19 @@
 								<name>rc32m_cal_inprogress</name>
 								<lsb>2</lsb>
 								<msb>2</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rc32m_rdy</name>
 								<lsb>1</lsb>
 								<msb>1</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rc32m_cal_done</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -18466,6 +18494,8 @@
 						<name>rc32m_ctrl1</name>
 						<description>rc32m_ctrl1.</description>
 						<addressOffset>0x304</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rc32m_reserved</name>
@@ -18503,6 +18533,8 @@
 						<name>pu_rst_clkpll</name>
 						<description>pu_rst_clkpll.</description>
 						<addressOffset>0x400</addressOffset>
+						<resetValue>0x000001f0</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>pu_clkpll</name>
@@ -18565,6 +18597,8 @@
 						<name>clkpll_top_ctrl</name>
 						<description>clkpll_top_ctrl.</description>
 						<addressOffset>0x404</addressOffset>
+						<resetValue>0x01100414</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>clkpll_vg13_sel</name>
@@ -18602,6 +18636,8 @@
 						<name>clkpll_cp</name>
 						<description>clkpll_cp.</description>
 						<addressOffset>0x408</addressOffset>
+						<resetValue>0x00000741</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>clkpll_cp_opamp_en</name>
@@ -18639,6 +18675,8 @@
 						<name>clkpll_rz</name>
 						<description>clkpll_rz.</description>
 						<addressOffset>0x40C</addressOffset>
+						<resetValue>0x0005a020</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>clkpll_rz</name>
@@ -18676,6 +18714,8 @@
 						<name>clkpll_fbdv</name>
 						<description>clkpll_fbdv.</description>
 						<addressOffset>0x410</addressOffset>
+						<resetValue>0x00000005</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>clkpll_sel_fb_clk</name>
@@ -18693,6 +18733,8 @@
 						<name>clkpll_vco</name>
 						<description>clkpll_vco.</description>
 						<addressOffset>0x414</addressOffset>
+						<resetValue>0x00000007</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>clkpll_shrtr</name>
@@ -18710,6 +18752,8 @@
 						<name>clkpll_sdm</name>
 						<description>clkpll_sdm.</description>
 						<addressOffset>0x418</addressOffset>
+						<resetValue>0x10600000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>clkpll_sdm_bypass</name>
@@ -18737,6 +18781,8 @@
 						<name>clkpll_output_en</name>
 						<description>clkpll_output_en.</description>
 						<addressOffset>0x41C</addressOffset>
+						<resetValue>0x00000100</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>clkpll_en_div2_480m</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -16795,11 +16795,14 @@
 						<name>DMA_IntStatus</name>
 						<description>DMA_IntStatus.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>IntStatus</name>
 								<lsb>0</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -16807,11 +16810,14 @@
 						<name>DMA_IntTCStatus</name>
 						<description>DMA_IntTCStatus.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>IntTCStatus</name>
 								<lsb>0</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -16819,11 +16825,14 @@
 						<name>DMA_IntTCClear</name>
 						<description>DMA_IntTCClear.</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>IntTCClear</name>
 								<lsb>0</lsb>
 								<msb>7</msb>
+								<access>write-only</access>
 							</field>
 						</fields>
 					</register>
@@ -16831,11 +16840,14 @@
 						<name>DMA_IntErrorStatus</name>
 						<description>DMA_IntErrorStatus.</description>
 						<addressOffset>0xC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>IntErrorStatus</name>
 								<lsb>0</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -16843,11 +16855,14 @@
 						<name>DMA_IntErrClr</name>
 						<description>DMA_IntErrClr.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>IntErrClr</name>
 								<lsb>0</lsb>
 								<msb>7</msb>
+								<access>write-only</access>
 							</field>
 						</fields>
 					</register>
@@ -16855,11 +16870,14 @@
 						<name>DMA_RawIntTCStatus</name>
 						<description>DMA_RawIntTCStatus.</description>
 						<addressOffset>0x14</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>RawIntTCStatus</name>
 								<lsb>0</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -16867,11 +16885,14 @@
 						<name>DMA_RawIntErrorStatus</name>
 						<description>DMA_RawIntErrorStatus.</description>
 						<addressOffset>0x18</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>RawIntErrorStatus</name>
 								<lsb>0</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -16879,11 +16900,14 @@
 						<name>DMA_EnbldChns</name>
 						<description>DMA_EnbldChns.</description>
 						<addressOffset>0x1C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>EnabledChannels</name>
 								<lsb>0</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -16891,6 +16915,8 @@
 						<name>DMA_SoftBReq</name>
 						<description>DMA_SoftBReq.</description>
 						<addressOffset>0x20</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>SoftBReq</name>
@@ -16903,6 +16929,8 @@
 						<name>DMA_SoftSReq</name>
 						<description>DMA_SoftSReq.</description>
 						<addressOffset>0x24</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>SoftSReq</name>
@@ -16915,6 +16943,8 @@
 						<name>DMA_SoftLBReq</name>
 						<description>DMA_SoftLBReq.</description>
 						<addressOffset>0x28</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>SoftLBReq</name>
@@ -16927,6 +16957,8 @@
 						<name>DMA_SoftLSReq</name>
 						<description>DMA_SoftLSReq.</description>
 						<addressOffset>0x2C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>SoftLSReq</name>
@@ -16939,6 +16971,8 @@
 						<name>DMA_Top_Config</name>
 						<description>DMA_Top_Config.</description>
 						<addressOffset>0x30</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>M</name>
@@ -16956,6 +16990,8 @@
 						<name>DMA_Sync</name>
 						<description>DMA_Sync.</description>
 						<addressOffset>0x34</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>DMA_Sync</name>
@@ -16968,6 +17004,8 @@
 						<name>DMA_C0SrcAddr</name>
 						<description>DMA_C0SrcAddr.</description>
 						<addressOffset>0x100</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>SrcAddr</name>
@@ -16980,6 +17018,8 @@
 						<name>DMA_C0DstAddr</name>
 						<description>DMA_C0DstAddr.</description>
 						<addressOffset>0x104</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>DstAddr</name>
@@ -16992,6 +17032,8 @@
 						<name>DMA_C0LLI</name>
 						<description>DMA_C0LLI.</description>
 						<addressOffset>0x108</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>LLI</name>
@@ -17004,6 +17046,8 @@
 						<name>DMA_C0Control</name>
 						<description>DMA_C0Control.</description>
 						<addressOffset>0x10C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>I</name>
@@ -17061,11 +17105,14 @@
 						<name>DMA_C0Config</name>
 						<description>DMA_C0Config.</description>
 						<addressOffset>0x110</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>LLICounter</name>
 								<lsb>20</lsb>
 								<msb>29</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>H</name>
@@ -17076,6 +17123,7 @@
 								<name>A</name>
 								<lsb>17</lsb>
 								<msb>17</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>L</name>
@@ -17118,6 +17166,8 @@
 						<name>DMA_C1SrcAddr</name>
 						<description>DMA_C1SrcAddr.</description>
 						<addressOffset>0x200</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>SrcAddr</name>
@@ -17130,6 +17180,8 @@
 						<name>DMA_C1DstAddr</name>
 						<description>DMA_C1DstAddr.</description>
 						<addressOffset>0x204</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>DstAddr</name>
@@ -17142,6 +17194,8 @@
 						<name>DMA_C1LLI</name>
 						<description>DMA_C1LLI.</description>
 						<addressOffset>0x208</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>LLI</name>
@@ -17154,6 +17208,8 @@
 						<name>DMA_C1Control</name>
 						<description>DMA_C1Control.</description>
 						<addressOffset>0x20C</addressOffset>
+						<resetValue>0x0c489000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>I</name>
@@ -17206,6 +17262,8 @@
 						<name>DMA_C1Config</name>
 						<description>DMA_C1Config.</description>
 						<addressOffset>0x210</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>H</name>
@@ -17216,6 +17274,7 @@
 								<name>A</name>
 								<lsb>17</lsb>
 								<msb>17</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>L</name>
@@ -17258,6 +17317,8 @@
 						<name>DMA_C2SrcAddr</name>
 						<description>DMA_C2SrcAddr.</description>
 						<addressOffset>0x300</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>SrcAddr</name>
@@ -17270,6 +17331,8 @@
 						<name>DMA_C2DstAddr</name>
 						<description>DMA_C2DstAddr.</description>
 						<addressOffset>0x304</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>DstAddr</name>
@@ -17282,6 +17345,8 @@
 						<name>DMA_C2LLI</name>
 						<description>DMA_C2LLI.</description>
 						<addressOffset>0x308</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>LLI</name>
@@ -17294,6 +17359,8 @@
 						<name>DMA_C2Control</name>
 						<description>DMA_C2Control.</description>
 						<addressOffset>0x30C</addressOffset>
+						<resetValue>0x0c489000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>I</name>
@@ -17346,6 +17413,8 @@
 						<name>DMA_C2Config</name>
 						<description>DMA_C2Config.</description>
 						<addressOffset>0x310</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>H</name>
@@ -17356,6 +17425,7 @@
 								<name>A</name>
 								<lsb>17</lsb>
 								<msb>17</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>L</name>
@@ -17398,6 +17468,8 @@
 						<name>DMA_C3SrcAddr</name>
 						<description>DMA_C3SrcAddr.</description>
 						<addressOffset>0x400</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>SrcAddr</name>
@@ -17410,6 +17482,8 @@
 						<name>DMA_C3DstAddr</name>
 						<description>DMA_C3DstAddr.</description>
 						<addressOffset>0x404</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>DstAddr</name>
@@ -17422,6 +17496,8 @@
 						<name>DMA_C3LLI</name>
 						<description>DMA_C3LLI.</description>
 						<addressOffset>0x408</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>LLI</name>
@@ -17434,6 +17510,8 @@
 						<name>DMA_C3Control</name>
 						<description>DMA_C3Control.</description>
 						<addressOffset>0x40C</addressOffset>
+						<resetValue>0x0c489000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>I</name>
@@ -17486,6 +17564,8 @@
 						<name>DMA_C3Config</name>
 						<description>DMA_C3Config.</description>
 						<addressOffset>0x410</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>H</name>
@@ -17496,6 +17576,7 @@
 								<name>A</name>
 								<lsb>17</lsb>
 								<msb>17</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>L</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -13093,11 +13093,13 @@
 								<name>rx_fifo_underflow</name>
 								<lsb>7</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rx_fifo_overflow</name>
 								<lsb>6</lsb>
 								<msb>6</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>tx_fifo_underflow</name>
@@ -13109,6 +13111,7 @@
 								<name>tx_fifo_overflow</name>
 								<lsb>4</lsb>
 								<msb>4</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rx_fifo_clr</name>
@@ -13202,6 +13205,8 @@
 						<name>spi_config</name>
 						<description>spi_config.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_spi_deg_cnt</name>
@@ -13264,6 +13269,8 @@
 						<name>spi_int_sts</name>
 						<description>spi_int_sts.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x3f003f00</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_spi_fer_en</name>
@@ -13359,31 +13366,37 @@
 								<name>spi_fer_int</name>
 								<lsb>5</lsb>
 								<msb>5</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>spi_txu_int</name>
 								<lsb>4</lsb>
 								<msb>4</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>spi_sto_int</name>
 								<lsb>3</lsb>
 								<msb>3</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>spi_rxf_int</name>
 								<lsb>2</lsb>
 								<msb>2</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>spi_txf_int</name>
 								<lsb>1</lsb>
 								<msb>1</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>spi_end_int</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -13391,6 +13404,9 @@
 						<name>spi_bus_busy</name>
 						<description>spi_bus_busy.</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>sts_spi_bus_busy</name>
@@ -13403,6 +13419,8 @@
 						<name>spi_prd_0</name>
 						<description>spi_prd_0.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x0f0f0f0f</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_spi_prd_d_ph_1</name>
@@ -13430,6 +13448,8 @@
 						<name>spi_prd_1</name>
 						<description>spi_prd_1.</description>
 						<addressOffset>0x14</addressOffset>
+						<resetValue>0x0000000f</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_spi_prd_i</name>
@@ -13442,6 +13462,8 @@
 						<name>spi_rxd_ignr</name>
 						<description>spi_rxd_ignr.</description>
 						<addressOffset>0x18</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_spi_rxd_ignr_s</name>
@@ -13459,6 +13481,8 @@
 						<name>spi_sto_value</name>
 						<description>spi_sto_value.</description>
 						<addressOffset>0x1C</addressOffset>
+						<resetValue>0x00000fff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_spi_sto_value</name>
@@ -13471,11 +13495,14 @@
 						<name>spi_fifo_config_0</name>
 						<description>spi_fifo_config_0.</description>
 						<addressOffset>0x80</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rx_fifo_underflow</name>
 								<lsb>7</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rx_fifo_overflow</name>
@@ -13487,11 +13514,13 @@
 								<name>tx_fifo_underflow</name>
 								<lsb>5</lsb>
 								<msb>5</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>tx_fifo_overflow</name>
 								<lsb>4</lsb>
 								<msb>4</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rx_fifo_clr</name>
@@ -13519,6 +13548,8 @@
 						<name>spi_fifo_config_1</name>
 						<description>spi_fifo_config_1.</description>
 						<addressOffset>0x84</addressOffset>
+						<resetValue>0x00000004</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rx_fifo_th</name>
@@ -13534,11 +13565,13 @@
 								<name>rx_fifo_cnt</name>
 								<lsb>8</lsb>
 								<msb>10</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>tx_fifo_cnt</name>
 								<lsb>0</lsb>
 								<msb>2</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -13923,11 +13956,13 @@
 								<name>rx_fifo_overflow</name>
 								<lsb>6</lsb>
 								<msb>6</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>tx_fifo_underflow</name>
 								<lsb>5</lsb>
 								<msb>5</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>tx_fifo_overflow</name>
@@ -13978,6 +14013,7 @@
 								<name>rx_fifo_cnt</name>
 								<lsb>8</lsb>
 								<msb>9</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>tx_fifo_cnt</name>
@@ -15697,11 +15733,13 @@
 								<name>rx_fifo_underflow</name>
 								<lsb>3</lsb>
 								<msb>3</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rx_fifo_overflow</name>
 								<lsb>2</lsb>
 								<msb>2</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rx_fifo_clr</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -33,7 +33,7 @@
 						<description>Clock configuration for processor and bus</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x6000000f</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>glb_id</name>
@@ -107,7 +107,7 @@
 						<description>clk_cfg1.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x01100001</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ble_en</name>
@@ -139,7 +139,7 @@
 						<description>Clock configuration for UART and Flash</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0xff8f2b17</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>dma_clk_en</name>
@@ -199,7 +199,7 @@
 						<description>Clock configuration for I2C and SPI</description>
 						<addressOffset>0xC</addressOffset>
 						<resetValue>0x01ff0103</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>i2c_clk_en</name>
@@ -228,7 +228,7 @@
 						<description>swrst_cfg0.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>swrst_s30</name>
@@ -257,7 +257,7 @@
 						<description>swrst_cfg1.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>swrst_s1a7</name>
@@ -386,7 +386,7 @@
 						<description>swrst_cfg2.</description>
 						<addressOffset>0x18</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pka_clk_sel</name>
@@ -420,7 +420,7 @@
 						<description>swrst_cfg3.</description>
 						<addressOffset>0x1C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -428,7 +428,7 @@
 						<description>cgen_cfg0.</description>
 						<addressOffset>0x20</addressOffset>
 						<resetValue>0x000000ff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cgen_m</name>
@@ -442,7 +442,7 @@
 						<description>cgen_cfg1.</description>
 						<addressOffset>0x24</addressOffset>
 						<resetValue>0x00ffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cgen_s1a</name>
@@ -461,7 +461,7 @@
 						<description>cgen_cfg2.</description>
 						<addressOffset>0x28</addressOffset>
 						<resetValue>0x00000011</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cgen_s3</name>
@@ -480,7 +480,7 @@
 						<description>cgen_cfg3.</description>
 						<addressOffset>0x2C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -488,7 +488,7 @@
 						<description>MBIST_CTL.</description>
 						<addressOffset>0x30</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_mbist_rst_n</name>
@@ -527,7 +527,7 @@
 						<description>MBIST_STAT.</description>
 						<addressOffset>0x34</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -587,7 +587,7 @@
 						<description>bmx_cfg1.</description>
 						<addressOffset>0x50</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>hbn_apb_cfg</name>
@@ -636,7 +636,7 @@
 						<description>bmx_cfg2.</description>
 						<addressOffset>0x54</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>bmx_dbg_sel</name>
@@ -668,7 +668,7 @@
 						<description>bmx_err_addr.</description>
 						<addressOffset>0x58</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -683,7 +683,7 @@
 						<description>bmx_dbg_out.</description>
 						<addressOffset>0x5C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -746,7 +746,7 @@
 						<description>sram_ret.</description>
 						<addressOffset>0x70</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_sram_ret</name>
@@ -760,7 +760,7 @@
 						<description>sram_slp.</description>
 						<addressOffset>0x74</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_sram_slp</name>
@@ -774,7 +774,7 @@
 						<description>sram_parm.</description>
 						<addressOffset>0x78</addressOffset>
 						<resetValue>0x0c0c0c0c</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_sram_parm</name>
@@ -788,7 +788,7 @@
 						<description>seam_misc.</description>
 						<addressOffset>0x7C</addressOffset>
 						<resetValue>0x00000003</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>em_sel</name>
@@ -802,7 +802,7 @@
 						<description>glb_parm.</description>
 						<addressOffset>0x80</addressOffset>
 						<resetValue>0x00018300</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>uart_swap_set</name>
@@ -896,7 +896,7 @@
 						<description>CPU_CLK_CFG.</description>
 						<addressOffset>0x90</addressOffset>
 						<resetValue>0x00080010</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>debug_ndreset_gate</name>
@@ -925,7 +925,7 @@
 						<description>Clock configuration for GPADC</description>
 						<addressOffset>0xA4</addressOffset>
 						<resetValue>0x00000102</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_32m_div_en</name>
@@ -949,7 +949,7 @@
 						<description>DIG32K_WAKEUP_CTRL.</description>
 						<addressOffset>0xA8</addressOffset>
 						<resetValue>0x033e13e8</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_en_platform_wakeup</name>
@@ -998,7 +998,7 @@
 						<description>WIFI_BT_COEX_CTRL.</description>
 						<addressOffset>0xAC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>en_gpio_bt_coex</name>
@@ -1027,7 +1027,7 @@
 						<description>UART_SIG_SEL_0.</description>
 						<addressOffset>0xC0</addressOffset>
 						<resetValue>0x76543210</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>uart_sig_7_sel</name>
@@ -1076,7 +1076,7 @@
 						<description>DBG_SEL_LL.</description>
 						<addressOffset>0xD0</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_dbg_ll_ctrl</name>
@@ -1090,7 +1090,7 @@
 						<description>DBG_SEL_LH.</description>
 						<addressOffset>0xD4</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_dbg_lh_ctrl</name>
@@ -1104,7 +1104,7 @@
 						<description>DBG_SEL_HL.</description>
 						<addressOffset>0xD8</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_dbg_hl_ctrl</name>
@@ -1118,7 +1118,7 @@
 						<description>DBG_SEL_HH.</description>
 						<addressOffset>0xDC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_dbg_hh_ctrl</name>
@@ -1132,7 +1132,7 @@
 						<description>debug.</description>
 						<addressOffset>0xE0</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>debug_i</name>
@@ -8901,7 +8901,7 @@
 						<description>led_driver.</description>
 						<addressOffset>0x224</addressOffset>
 						<resetValue>0x00000080</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pu_leddrv</name>
@@ -8940,7 +8940,7 @@
 						<description>gpdac_ctrl.</description>
 						<addressOffset>0x308</addressOffset>
 						<resetValue>0x00000003</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpdac_reserved</name>
@@ -8979,7 +8979,7 @@
 						<description>gpdac_actrl.</description>
 						<addressOffset>0x30C</addressOffset>
 						<resetValue>0x000c0000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpdac_a_outmux</name>
@@ -9008,7 +9008,7 @@
 						<description>gpdac_bctrl.</description>
 						<addressOffset>0x310</addressOffset>
 						<resetValue>0x000c0000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpdac_b_outmux</name>
@@ -9037,7 +9037,7 @@
 						<description>gpdac_data.</description>
 						<addressOffset>0x314</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpdac_a_data</name>
@@ -9056,7 +9056,7 @@
 						<description>tzc_glb_ctrl_0.</description>
 						<addressOffset>0xF00</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -9136,7 +9136,7 @@
 						<description>tzc_glb_ctrl_1.</description>
 						<addressOffset>0xF04</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -9306,7 +9306,7 @@
 						<description>tzc_glb_ctrl_2.</description>
 						<addressOffset>0xF08</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -14503,7 +14503,7 @@
 						<description>gpadc_config.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rsvd_31_24</name>
@@ -14598,7 +14598,7 @@
 						<description>gpadc_dma_rdata.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -14618,7 +14618,7 @@
 						<description>gpdac_config.</description>
 						<addressOffset>0x40</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rsvd_31_24</name>
@@ -14662,7 +14662,7 @@
 						<description>gpdac_dma_config.</description>
 						<addressOffset>0x44</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpdac_dma_format</name>
@@ -14681,7 +14681,7 @@
 						<description>gpdac_dma_wdata.</description>
 						<addressOffset>0x48</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>write-only</access>
 						<fields>
 							<field>
@@ -14696,7 +14696,7 @@
 						<description>gpdac_tx_fifo_status.</description>
 						<addressOffset>0x4C</addressOffset>
 						<resetValue>0x00000040</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -14746,7 +14746,7 @@
 						<description>sd_chip_id_low.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -14761,7 +14761,7 @@
 						<description>sd_chip_id_high.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -14776,7 +14776,7 @@
 						<description>sd_wifi_mac_low.</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -14791,7 +14791,7 @@
 						<description>sd_wifi_mac_high.</description>
 						<addressOffset>0xC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -14806,7 +14806,7 @@
 						<description>sd_dbg_pwd_low.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sd_dbg_pwd_low</name>
@@ -14820,7 +14820,7 @@
 						<description>sd_dbg_pwd_high.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sd_dbg_pwd_high</name>
@@ -14834,7 +14834,7 @@
 						<description>sd_status.</description>
 						<addressOffset>0x18</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sd_dbg_ena</name>
@@ -14909,7 +14909,7 @@
 						<description>se_sha_0_ctrl.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_sha_0_msg_len</name>
@@ -14975,7 +14975,7 @@
 						<description>se_sha_0_msa.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_sha_0_msa</name>
@@ -14989,7 +14989,7 @@
 						<description>se_sha_0_status.</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0x00000041</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15004,7 +15004,7 @@
 						<description>se_sha_0_endian.</description>
 						<addressOffset>0xC</addressOffset>
 						<resetValue>0x00000001</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_sha_0_dout_endian</name>
@@ -15018,7 +15018,7 @@
 						<description>se_sha_0_hash_l_0.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15033,7 +15033,7 @@
 						<description>se_sha_0_hash_l_1.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15048,7 +15048,7 @@
 						<description>se_sha_0_hash_l_2.</description>
 						<addressOffset>0x18</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15063,7 +15063,7 @@
 						<description>se_sha_0_hash_l_3.</description>
 						<addressOffset>0x1C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15078,7 +15078,7 @@
 						<description>se_sha_0_hash_l_4.</description>
 						<addressOffset>0x20</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15093,7 +15093,7 @@
 						<description>se_sha_0_hash_l_5.</description>
 						<addressOffset>0x24</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15108,7 +15108,7 @@
 						<description>se_sha_0_hash_l_6.</description>
 						<addressOffset>0x28</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15123,7 +15123,7 @@
 						<description>se_sha_0_hash_l_7.</description>
 						<addressOffset>0x2C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15138,7 +15138,7 @@
 						<description>se_sha_0_hash_h_0.</description>
 						<addressOffset>0x30</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15153,7 +15153,7 @@
 						<description>se_sha_0_hash_h_1.</description>
 						<addressOffset>0x34</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15168,7 +15168,7 @@
 						<description>se_sha_0_hash_h_2.</description>
 						<addressOffset>0x38</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15183,7 +15183,7 @@
 						<description>se_sha_0_hash_h_3.</description>
 						<addressOffset>0x3C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15198,7 +15198,7 @@
 						<description>se_sha_0_hash_h_4.</description>
 						<addressOffset>0x40</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15213,7 +15213,7 @@
 						<description>se_sha_0_hash_h_5.</description>
 						<addressOffset>0x44</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15228,7 +15228,7 @@
 						<description>se_sha_0_hash_h_6.</description>
 						<addressOffset>0x48</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15243,7 +15243,7 @@
 						<description>se_sha_0_hash_h_7.</description>
 						<addressOffset>0x4C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15258,7 +15258,7 @@
 						<description>se_sha_0_link.</description>
 						<addressOffset>0x50</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_sha_0_lca</name>
@@ -15272,7 +15272,7 @@
 						<description>se_sha_0_ctrl_prot.</description>
 						<addressOffset>0xFC</addressOffset>
 						<resetValue>0x00000007</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_sha_id1_en</name>
@@ -15296,7 +15296,7 @@
 						<description>se_aes_0_ctrl.</description>
 						<addressOffset>0x100</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_msg_len</name>
@@ -15382,7 +15382,7 @@
 						<description>se_aes_0_msa.</description>
 						<addressOffset>0x104</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_msa</name>
@@ -15396,7 +15396,7 @@
 						<description>se_aes_0_mda.</description>
 						<addressOffset>0x108</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_mda</name>
@@ -15410,7 +15410,7 @@
 						<description>se_aes_0_status.</description>
 						<addressOffset>0x10C</addressOffset>
 						<resetValue>0x00000100</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15425,7 +15425,7 @@
 						<description>se_aes_0_iv_0.</description>
 						<addressOffset>0x110</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_iv_0</name>
@@ -15439,7 +15439,7 @@
 						<description>se_aes_0_iv_1.</description>
 						<addressOffset>0x114</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_iv_1</name>
@@ -15453,7 +15453,7 @@
 						<description>se_aes_0_iv_2.</description>
 						<addressOffset>0x118</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_iv_2</name>
@@ -15467,7 +15467,7 @@
 						<description>se_aes_0_iv_3.</description>
 						<addressOffset>0x11C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_iv_3</name>
@@ -15481,7 +15481,7 @@
 						<description>se_aes_0_key_0.</description>
 						<addressOffset>0x120</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_key_0</name>
@@ -15495,7 +15495,7 @@
 						<description>se_aes_0_key_1.</description>
 						<addressOffset>0x124</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_key_1</name>
@@ -15509,7 +15509,7 @@
 						<description>se_aes_0_key_2.</description>
 						<addressOffset>0x128</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_key_2</name>
@@ -15523,7 +15523,7 @@
 						<description>se_aes_0_key_3.</description>
 						<addressOffset>0x12C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_key_3</name>
@@ -15537,7 +15537,7 @@
 						<description>se_aes_0_key_4.</description>
 						<addressOffset>0x130</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_key_4</name>
@@ -15551,7 +15551,7 @@
 						<description>se_aes_0_key_5.</description>
 						<addressOffset>0x134</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_key_5</name>
@@ -15565,7 +15565,7 @@
 						<description>se_aes_0_key_6.</description>
 						<addressOffset>0x138</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_key_6</name>
@@ -15579,7 +15579,7 @@
 						<description>se_aes_0_key_7.</description>
 						<addressOffset>0x13C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_key_7</name>
@@ -15593,7 +15593,7 @@
 						<description>se_aes_0_key_sel_0.</description>
 						<addressOffset>0x140</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_key_sel_0</name>
@@ -15607,7 +15607,7 @@
 						<description>se_aes_0_key_sel_1.</description>
 						<addressOffset>0x144</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_key_sel_1</name>
@@ -15621,7 +15621,7 @@
 						<description>se_aes_0_endian.</description>
 						<addressOffset>0x148</addressOffset>
 						<resetValue>0x0000000f</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_ctr_len</name>
@@ -15655,7 +15655,7 @@
 						<description>se_aes_0_sboot.</description>
 						<addressOffset>0x14C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_sboot_key_sel</name>
@@ -15669,7 +15669,7 @@
 						<description>se_aes_0_link.</description>
 						<addressOffset>0x150</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_0_lca</name>
@@ -15683,7 +15683,7 @@
 						<description>se_aes_0_ctrl_prot.</description>
 						<addressOffset>0x1FC</addressOffset>
 						<resetValue>0x00000007</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_aes_id1_en</name>
@@ -15707,7 +15707,7 @@
 						<description>se_trng_0_ctrl_0.</description>
 						<addressOffset>0x200</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_trng_0_manual_en</name>
@@ -15779,7 +15779,7 @@
 						<description>se_trng_0_status.</description>
 						<addressOffset>0x204</addressOffset>
 						<resetValue>0x00100020</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15794,7 +15794,7 @@
 						<description>se_trng_0_dout_0.</description>
 						<addressOffset>0x208</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15809,7 +15809,7 @@
 						<description>se_trng_0_dout_1.</description>
 						<addressOffset>0x20C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15824,7 +15824,7 @@
 						<description>se_trng_0_dout_2.</description>
 						<addressOffset>0x210</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15839,7 +15839,7 @@
 						<description>se_trng_0_dout_3.</description>
 						<addressOffset>0x214</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15854,7 +15854,7 @@
 						<description>se_trng_0_dout_4.</description>
 						<addressOffset>0x218</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15869,7 +15869,7 @@
 						<description>se_trng_0_dout_5.</description>
 						<addressOffset>0x21C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15884,7 +15884,7 @@
 						<description>se_trng_0_dout_6.</description>
 						<addressOffset>0x220</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15899,7 +15899,7 @@
 						<description>se_trng_0_dout_7.</description>
 						<addressOffset>0x224</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -15914,7 +15914,7 @@
 						<description>se_trng_0_test.</description>
 						<addressOffset>0x228</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_trng_0_ht_alarm_n</name>
@@ -15948,7 +15948,7 @@
 						<description>se_trng_0_ctrl_1.</description>
 						<addressOffset>0x22C</addressOffset>
 						<resetValue>0x0000ffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_trng_0_reseed_n_lsb</name>
@@ -15962,7 +15962,7 @@
 						<description>se_trng_0_ctrl_2.</description>
 						<addressOffset>0x230</addressOffset>
 						<resetValue>0x000000ff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_trng_0_reseed_n_msb</name>
@@ -15976,7 +15976,7 @@
 						<description>se_trng_0_ctrl_3.</description>
 						<addressOffset>0x234</addressOffset>
 						<resetValue>0x837a4203</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_trng_0_rosc_dis</name>
@@ -16011,7 +16011,7 @@
 						<description>se_trng_0_test_out_0.</description>
 						<addressOffset>0x240</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -16026,7 +16026,7 @@
 						<description>se_trng_0_test_out_1.</description>
 						<addressOffset>0x244</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -16041,7 +16041,7 @@
 						<description>se_trng_0_test_out_2.</description>
 						<addressOffset>0x248</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -16056,7 +16056,7 @@
 						<description>se_trng_0_test_out_3.</description>
 						<addressOffset>0x24C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -16071,7 +16071,7 @@
 						<description>se_trng_0_ctrl_prot.</description>
 						<addressOffset>0x2FC</addressOffset>
 						<resetValue>0x00000007</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_trng_id1_en</name>
@@ -16095,7 +16095,7 @@
 						<description>se_pka_0_ctrl_0.</description>
 						<addressOffset>0x300</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_pka_0_status</name>
@@ -16173,7 +16173,7 @@
 						<description>se_pka_0_seed.</description>
 						<addressOffset>0x30C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_pka_0_seed</name>
@@ -16187,7 +16187,7 @@
 						<description>se_pka_0_ctrl_1.</description>
 						<addressOffset>0x310</addressOffset>
 						<resetValue>0x00000005</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_pka_0_hbypass</name>
@@ -16206,7 +16206,7 @@
 						<description>se_pka_0_rw.</description>
 						<addressOffset>0x340</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -16214,7 +16214,7 @@
 						<description>se_pka_0_rw_burst.</description>
 						<addressOffset>0x360</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -16222,7 +16222,7 @@
 						<description>se_pka_0_ctrl_prot.</description>
 						<addressOffset>0x3FC</addressOffset>
 						<resetValue>0x00000007</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_pka_id1_en</name>
@@ -16246,7 +16246,7 @@
 						<description>se_cdet_0_ctrl_0.</description>
 						<addressOffset>0x400</addressOffset>
 						<resetValue>0x21640004</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_cdet_0_g_loop_min</name>
@@ -16282,7 +16282,7 @@
 						<description>se_cdet_0_ctrl_1.</description>
 						<addressOffset>0x404</addressOffset>
 						<resetValue>0x00ff0332</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_cdet_0_g_slp_n</name>
@@ -16306,7 +16306,7 @@
 						<description>se_cdet_0_ctrl_prot.</description>
 						<addressOffset>0x4FC</addressOffset>
 						<resetValue>0x00000007</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_cdet_id1_en</name>
@@ -16330,7 +16330,7 @@
 						<description>se_gmac_0_ctrl_0.</description>
 						<addressOffset>0x500</addressOffset>
 						<resetValue>0x00007000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_gmac_0_x_endian</name>
@@ -16391,7 +16391,7 @@
 						<description>se_gmac_0_lca.</description>
 						<addressOffset>0x504</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_gmac_0_lca</name>
@@ -16405,7 +16405,7 @@
 						<description>se_gmac_0_status.</description>
 						<addressOffset>0x508</addressOffset>
 						<resetValue>0xf1000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -16420,7 +16420,7 @@
 						<description>se_gmac_0_ctrl_prot.</description>
 						<addressOffset>0x5FC</addressOffset>
 						<resetValue>0x00000007</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>se_gmac_id1_en</name>
@@ -16444,7 +16444,7 @@
 						<description>se_ctrl_prot_rd.</description>
 						<addressOffset>0xF00</addressOffset>
 						<resetValue>0x00777777</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -16600,7 +16600,7 @@
 						<description>tzc_rom_ctrl.</description>
 						<addressOffset>0x40</addressOffset>
 						<resetValue>0x00000f0f</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tzc_sboot_done</name>
@@ -16694,7 +16694,7 @@
 						<description>tzc_rom0_r0.</description>
 						<addressOffset>0x44</addressOffset>
 						<resetValue>0x0000ffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tzc_rom0_r0_start</name>
@@ -16713,7 +16713,7 @@
 						<description>tzc_rom0_r1.</description>
 						<addressOffset>0x48</addressOffset>
 						<resetValue>0x0000ffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tzc_rom0_r1_start</name>
@@ -16732,7 +16732,7 @@
 						<description>tzc_rom1_r0.</description>
 						<addressOffset>0x4C</addressOffset>
 						<resetValue>0x0000ffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tzc_rom1_r0_start</name>
@@ -16751,7 +16751,7 @@
 						<description>tzc_rom1_r1.</description>
 						<addressOffset>0x50</addressOffset>
 						<resetValue>0x0000ffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tzc_rom1_r1_start</name>
@@ -16785,7 +16785,7 @@
 						<description>tzc_rom_ctrl.</description>
 						<addressOffset>0x40</addressOffset>
 						<resetValue>0x00000f0f</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -16880,7 +16880,7 @@
 						<description>tzc_rom0_r0.</description>
 						<addressOffset>0x44</addressOffset>
 						<resetValue>0x0000ffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -16900,7 +16900,7 @@
 						<description>tzc_rom0_r1.</description>
 						<addressOffset>0x48</addressOffset>
 						<resetValue>0x0000ffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -16920,7 +16920,7 @@
 						<description>tzc_rom1_r0.</description>
 						<addressOffset>0x4C</addressOffset>
 						<resetValue>0x0000ffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -16940,7 +16940,7 @@
 						<description>tzc_rom1_r1.</description>
 						<addressOffset>0x50</addressOffset>
 						<resetValue>0x0000ffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -16975,7 +16975,7 @@
 						<description>ef_cfg_0.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_dbg_mode</name>
@@ -17084,7 +17084,7 @@
 						<description>ef_dbg_pwd_low.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_dbg_pwd_low</name>
@@ -17098,7 +17098,7 @@
 						<description>ef_dbg_pwd_high.</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_dbg_pwd_high</name>
@@ -17112,7 +17112,7 @@
 						<description>ef_ana_trim_0.</description>
 						<addressOffset>0xC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_ana_trim_0</name>
@@ -17126,7 +17126,7 @@
 						<description>ef_sw_usage_0.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_sw_usage_0</name>
@@ -17140,7 +17140,7 @@
 						<description>ef_wifi_mac_low.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_wifi_mac_low</name>
@@ -17154,7 +17154,7 @@
 						<description>ef_wifi_mac_high.</description>
 						<addressOffset>0x18</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_wifi_mac_high</name>
@@ -17168,7 +17168,7 @@
 						<description>ef_key_slot_0_w0.</description>
 						<addressOffset>0x1C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_0_w0</name>
@@ -17182,7 +17182,7 @@
 						<description>ef_key_slot_0_w1.</description>
 						<addressOffset>0x20</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_0_w1</name>
@@ -17196,7 +17196,7 @@
 						<description>ef_key_slot_0_w2.</description>
 						<addressOffset>0x24</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_0_w2</name>
@@ -17210,7 +17210,7 @@
 						<description>ef_key_slot_0_w3.</description>
 						<addressOffset>0x28</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_0_w3</name>
@@ -17224,7 +17224,7 @@
 						<description>ef_key_slot_1_w0.</description>
 						<addressOffset>0x2C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_1_w0</name>
@@ -17238,7 +17238,7 @@
 						<description>ef_key_slot_1_w1.</description>
 						<addressOffset>0x30</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_1_w1</name>
@@ -17252,7 +17252,7 @@
 						<description>ef_key_slot_1_w2.</description>
 						<addressOffset>0x34</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_1_w2</name>
@@ -17266,7 +17266,7 @@
 						<description>ef_key_slot_1_w3.</description>
 						<addressOffset>0x38</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_1_w3</name>
@@ -17280,7 +17280,7 @@
 						<description>ef_key_slot_2_w0.</description>
 						<addressOffset>0x3C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_2_w0</name>
@@ -17294,7 +17294,7 @@
 						<description>ef_key_slot_2_w1.</description>
 						<addressOffset>0x40</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_2_w1</name>
@@ -17308,7 +17308,7 @@
 						<description>ef_key_slot_2_w2.</description>
 						<addressOffset>0x44</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_2_w2</name>
@@ -17322,7 +17322,7 @@
 						<description>ef_key_slot_2_w3.</description>
 						<addressOffset>0x48</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_2_w3</name>
@@ -17336,7 +17336,7 @@
 						<description>ef_key_slot_3_w0.</description>
 						<addressOffset>0x4C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_3_w0</name>
@@ -17350,7 +17350,7 @@
 						<description>ef_key_slot_3_w1.</description>
 						<addressOffset>0x50</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_3_w1</name>
@@ -17364,7 +17364,7 @@
 						<description>ef_key_slot_3_w2.</description>
 						<addressOffset>0x54</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_3_w2</name>
@@ -17378,7 +17378,7 @@
 						<description>ef_key_slot_3_w3.</description>
 						<addressOffset>0x58</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_3_w3</name>
@@ -17392,7 +17392,7 @@
 						<description>ef_key_slot_4_w0.</description>
 						<addressOffset>0x5C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_4_w0</name>
@@ -17406,7 +17406,7 @@
 						<description>ef_key_slot_4_w1.</description>
 						<addressOffset>0x60</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_4_w1</name>
@@ -17420,7 +17420,7 @@
 						<description>ef_key_slot_4_w2.</description>
 						<addressOffset>0x64</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_4_w2</name>
@@ -17434,7 +17434,7 @@
 						<description>ef_key_slot_4_w3.</description>
 						<addressOffset>0x68</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_4_w3</name>
@@ -17448,7 +17448,7 @@
 						<description>ef_key_slot_5_w0.</description>
 						<addressOffset>0x6C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_5_w0</name>
@@ -17462,7 +17462,7 @@
 						<description>ef_key_slot_5_w1.</description>
 						<addressOffset>0x70</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_5_w1</name>
@@ -17476,7 +17476,7 @@
 						<description>ef_key_slot_5_w2.</description>
 						<addressOffset>0x74</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_5_w2</name>
@@ -17490,7 +17490,7 @@
 						<description>ef_key_slot_5_w3.</description>
 						<addressOffset>0x78</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_key_slot_5_w3</name>
@@ -17504,7 +17504,7 @@
 						<description>ef_data_0_lock.</description>
 						<addressOffset>0x7C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rd_lock_key_slot_5</name>
@@ -17628,7 +17628,7 @@
 						<description>reg_key_slot_6_w0.</description>
 						<addressOffset>0x00</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_6_w0</name>
@@ -17642,7 +17642,7 @@
 						<description>reg_key_slot_6_w1.</description>
 						<addressOffset>0x04</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_6_w1</name>
@@ -17656,7 +17656,7 @@
 						<description>reg_key_slot_6_w2.</description>
 						<addressOffset>0x08</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_6_w2</name>
@@ -17670,7 +17670,7 @@
 						<description>reg_key_slot_6_w3.</description>
 						<addressOffset>0x0C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_6_w3</name>
@@ -17684,7 +17684,7 @@
 						<description>reg_key_slot_7_w0.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_7_w0</name>
@@ -17698,7 +17698,7 @@
 						<description>reg_key_slot_7_w1.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_7_w1</name>
@@ -17712,7 +17712,7 @@
 						<description>reg_key_slot_7_w2.</description>
 						<addressOffset>0x18</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_7_w2</name>
@@ -17726,7 +17726,7 @@
 						<description>reg_key_slot_7_w3.</description>
 						<addressOffset>0x1C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_7_w3</name>
@@ -17740,7 +17740,7 @@
 						<description>reg_key_slot_8_w0.</description>
 						<addressOffset>0x20</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_8_w0</name>
@@ -17754,7 +17754,7 @@
 						<description>reg_key_slot_8_w1.</description>
 						<addressOffset>0x24</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_8_w1</name>
@@ -17768,7 +17768,7 @@
 						<description>reg_key_slot_8_w2.</description>
 						<addressOffset>0x28</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_8_w2</name>
@@ -17782,7 +17782,7 @@
 						<description>reg_key_slot_8_w3.</description>
 						<addressOffset>0x2C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_8_w3</name>
@@ -17796,7 +17796,7 @@
 						<description>reg_key_slot_9_w0.</description>
 						<addressOffset>0x30</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_9_w0</name>
@@ -17810,7 +17810,7 @@
 						<description>reg_key_slot_9_w1.</description>
 						<addressOffset>0x34</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_9_w1</name>
@@ -17824,7 +17824,7 @@
 						<description>reg_key_slot_9_w2.</description>
 						<addressOffset>0x38</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_9_w2</name>
@@ -17838,7 +17838,7 @@
 						<description>reg_key_slot_9_w3.</description>
 						<addressOffset>0x3C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_key_slot_9_w3</name>
@@ -17852,7 +17852,7 @@
 						<description>reg_key_slot_10_w0.</description>
 						<addressOffset>0x40</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -17860,7 +17860,7 @@
 						<description>reg_key_slot_10_w1.</description>
 						<addressOffset>0x44</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -17868,7 +17868,7 @@
 						<description>reg_key_slot_10_w2.</description>
 						<addressOffset>0x48</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -17876,7 +17876,7 @@
 						<description>reg_key_slot_10_w3.</description>
 						<addressOffset>0x4C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -17884,7 +17884,7 @@
 						<description>reg_key_slot_11_w0.</description>
 						<addressOffset>0x50</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -17892,7 +17892,7 @@
 						<description>reg_key_slot_11_w1.</description>
 						<addressOffset>0x54</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -17900,7 +17900,7 @@
 						<description>reg_key_slot_11_w2.</description>
 						<addressOffset>0x58</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -17908,7 +17908,7 @@
 						<description>reg_key_slot_11_w3.</description>
 						<addressOffset>0x5C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -17916,7 +17916,7 @@
 						<description>reg_data_1_lock.</description>
 						<addressOffset>0x60</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rd_lock_key_slot_9</name>
@@ -17990,7 +17990,7 @@
 						<description>ef_if_ctrl_0.</description>
 						<addressOffset>0x000</addressOffset>
 						<resetValue>0x00240003</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_if_prot_code_cyc</name>
@@ -18088,7 +18088,7 @@
 						<description>ef_if_cyc_0.</description>
 						<addressOffset>0x004</addressOffset>
 						<resetValue>0x16000040</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_if_cyc_pd_cs_s</name>
@@ -18122,7 +18122,7 @@
 						<description>ef_if_cyc_1.</description>
 						<addressOffset>0x008</addressOffset>
 						<resetValue>0x00206609</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_if_cyc_pd_cs_h</name>
@@ -18156,7 +18156,7 @@
 						<description>ef_if_0_manual.</description>
 						<addressOffset>0x00C</addressOffset>
 						<resetValue>0x0000e400</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_if_prot_code_manual</name>
@@ -18211,7 +18211,7 @@
 						<description>ef_if_0_status.</description>
 						<addressOffset>0x010</addressOffset>
 						<resetValue>0x0000e400</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_if_0_status</name>
@@ -18226,7 +18226,7 @@
 						<description>ef_if_cfg_0.</description>
 						<addressOffset>0x014</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -18450,7 +18450,7 @@
 						<description>ef_if_ana_trim_0.</description>
 						<addressOffset>0x020</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_if_ana_trim_0</name>
@@ -18465,7 +18465,7 @@
 						<description>ef_if_sw_usage_0.</description>
 						<addressOffset>0x024</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_if_sw_usage_0</name>
@@ -18480,7 +18480,7 @@
 						<description>ef_crc_ctrl_0.</description>
 						<addressOffset>0x200</addressOffset>
 						<resetValue>0x00ff0224</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_crc_slp_n</name>
@@ -18557,7 +18557,7 @@
 						<description>ef_crc_ctrl_1.</description>
 						<addressOffset>0x204</addressOffset>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_crc_data_0_en</name>
@@ -18571,7 +18571,7 @@
 						<description>ef_crc_ctrl_2.</description>
 						<addressOffset>0x208</addressOffset>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_crc_data_1_en</name>
@@ -18585,7 +18585,7 @@
 						<description>ef_crc_ctrl_3.</description>
 						<addressOffset>0x20C</addressOffset>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_crc_iv</name>
@@ -18599,7 +18599,7 @@
 						<description>ef_crc_ctrl_4.</description>
 						<addressOffset>0x210</addressOffset>
 						<resetValue>0xc2a8fa9d</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_crc_golden</name>
@@ -18613,7 +18613,7 @@
 						<description>ef_crc_ctrl_5.</description>
 						<addressOffset>0x214</addressOffset>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ef_crc_dout</name>
@@ -18643,7 +18643,7 @@
 						<description>cci_cfg.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x00000221</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>reg_mcci_clk_inv</name>
@@ -18697,7 +18697,7 @@
 						<description>cci_addr.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>apb_cci_addr</name>
@@ -18711,7 +18711,7 @@
 						<description>cci_wdata.</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>apb_cci_wdata</name>
@@ -18725,7 +18725,7 @@
 						<description>cci_rdata.</description>
 						<addressOffset>0xC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>apb_cci_rdata</name>
@@ -18740,7 +18740,7 @@
 						<description>cci_ctl.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ahb_state</name>
@@ -18782,7 +18782,7 @@
 						<description>l1c_config.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x06000f00</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>wrap_dis</name>
@@ -18857,7 +18857,7 @@
 						<description>hit_cnt_lsb.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -18872,7 +18872,7 @@
 						<description>hit_cnt_msb.</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -18887,7 +18887,7 @@
 						<description>miss_cnt.</description>
 						<addressOffset>0xC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -18902,7 +18902,7 @@
 						<description>l1c_range.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -18910,7 +18910,7 @@
 						<description>l1c_bmx_err_addr_en.</description>
 						<addressOffset>0x200</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>l1c_hsel_option</name>
@@ -18941,7 +18941,7 @@
 						<description>l1c_bmx_err_addr.</description>
 						<addressOffset>0x204</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -18956,7 +18956,7 @@
 						<description>irom1_misr_dataout_0.</description>
 						<addressOffset>0x208</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -18971,7 +18971,7 @@
 						<description>irom1_misr_dataout_1.</description>
 						<addressOffset>0x20C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields/>
 					</register>
 					<register>
@@ -18979,7 +18979,7 @@
 						<description>cpu_clk_gate.</description>
 						<addressOffset>0x210</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>force_e21_clock_on_2</name>
@@ -19018,7 +19018,7 @@
 						<description>utx_config.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x00001700</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_utx_len</name>
@@ -19077,7 +19077,7 @@
 						<description>urx_config.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x00000700</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_urx_len</name>
@@ -19146,7 +19146,7 @@
 						<description>uart_bit_prd.</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0x00ff00ff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_urx_bit_prd</name>
@@ -19165,7 +19165,7 @@
 						<description>data_config.</description>
 						<addressOffset>0xC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_uart_bit_inv</name>
@@ -19179,7 +19179,7 @@
 						<description>utx_ir_position.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x009f0070</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_utx_ir_pos_p</name>
@@ -19198,7 +19198,7 @@
 						<description>urx_ir_position.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0x0000006f</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_urx_ir_pos_s</name>
@@ -19212,7 +19212,7 @@
 						<description>urx_rto_timer.</description>
 						<addressOffset>0x18</addressOffset>
 						<resetValue>0x0000000f</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_urx_rto_value</name>
@@ -19226,7 +19226,7 @@
 						<description>UART interrupt status</description>
 						<addressOffset>0x20</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -19276,7 +19276,7 @@
 						<description>UART interrupt mask</description>
 						<addressOffset>0x24</addressOffset>
 						<resetValue>0x000000ff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_urx_fer_mask</name>
@@ -19325,7 +19325,7 @@
 						<description>UART interrupt clear</description>
 						<addressOffset>0x28</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rsvd_7</name>
@@ -19374,7 +19374,7 @@
 						<description>UART interrupt enable</description>
 						<addressOffset>0x2C</addressOffset>
 						<resetValue>0x000000ff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_urx_fer_en</name>
@@ -19423,7 +19423,7 @@
 						<description>uart_status.</description>
 						<addressOffset>0x30</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -19443,7 +19443,7 @@
 						<description>sts_urx_abr_prd.</description>
 						<addressOffset>0x34</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -19463,7 +19463,7 @@
 						<description>uart_fifo_config_0.</description>
 						<addressOffset>0x80</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rx_fifo_underflow</name>
@@ -19516,7 +19516,7 @@
 						<description>uart_fifo_config_1.</description>
 						<addressOffset>0x84</addressOffset>
 						<resetValue>0x00000020</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rx_fifo_th</name>
@@ -19547,7 +19547,7 @@
 						<description>uart_fifo_wdata.</description>
 						<addressOffset>0x88</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>write-only</access>
 						<fields>
 							<field>
@@ -19562,7 +19562,7 @@
 						<description>uart_fifo_rdata.</description>
 						<addressOffset>0x8C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -19592,7 +19592,7 @@
 						<description>spi_config.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_spi_deg_cnt</name>
@@ -19656,7 +19656,7 @@
 						<description>spi_int_sts.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x3f003f00</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_spi_fer_en</name>
@@ -19791,7 +19791,7 @@
 						<description>spi_bus_busy.</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -19806,7 +19806,7 @@
 						<description>spi_prd_0.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x0f0f0f0f</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_spi_prd_d_ph_1</name>
@@ -19835,7 +19835,7 @@
 						<description>spi_prd_1.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0x0000000f</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_spi_prd_i</name>
@@ -19849,7 +19849,7 @@
 						<description>spi_rxd_ignr.</description>
 						<addressOffset>0x18</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_spi_rxd_ignr_s</name>
@@ -19868,7 +19868,7 @@
 						<description>spi_sto_value.</description>
 						<addressOffset>0x1C</addressOffset>
 						<resetValue>0x00000fff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_spi_sto_value</name>
@@ -19882,7 +19882,7 @@
 						<description>spi_fifo_config_0.</description>
 						<addressOffset>0x80</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rx_fifo_underflow</name>
@@ -19935,7 +19935,7 @@
 						<description>spi_fifo_config_1.</description>
 						<addressOffset>0x84</addressOffset>
 						<resetValue>0x00000004</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rx_fifo_th</name>
@@ -19966,7 +19966,7 @@
 						<description>spi_fifo_wdata.</description>
 						<addressOffset>0x88</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>write-only</access>
 						<fields>
 							<field>
@@ -19981,7 +19981,7 @@
 						<description>spi_fifo_rdata.</description>
 						<addressOffset>0x8C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -20011,7 +20011,7 @@
 						<description>i2c_config.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x0000000a</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_i2c_deg_cnt</name>
@@ -20065,7 +20065,7 @@
 						<description>i2c_int_sts.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x3f003f00</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_i2c_fer_en</name>
@@ -20200,7 +20200,7 @@
 						<description>i2c_sub_addr.</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_i2c_sub_addr_b3</name>
@@ -20229,7 +20229,7 @@
 						<description>i2c_bus_busy.</description>
 						<addressOffset>0xC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_i2c_bus_busy_clr</name>
@@ -20249,7 +20249,7 @@
 						<description>i2c_prd_start.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x0f0f0f0f</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_i2c_prd_s_ph_3</name>
@@ -20278,7 +20278,7 @@
 						<description>i2c_prd_stop.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0x0f0f0f0f</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_i2c_prd_p_ph_3</name>
@@ -20307,7 +20307,7 @@
 						<description>i2c_prd_data.</description>
 						<addressOffset>0x18</addressOffset>
 						<resetValue>0x0f0f0f0f</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_i2c_prd_d_ph_3</name>
@@ -20336,7 +20336,7 @@
 						<description>i2c_fifo_config_0.</description>
 						<addressOffset>0x80</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rx_fifo_underflow</name>
@@ -20389,7 +20389,7 @@
 						<description>i2c_fifo_config_1.</description>
 						<addressOffset>0x84</addressOffset>
 						<resetValue>0x00000002</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rx_fifo_th</name>
@@ -20420,7 +20420,7 @@
 						<description>i2c_fifo_wdata.</description>
 						<addressOffset>0x88</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>write-only</access>
 						<fields>
 							<field>
@@ -20435,7 +20435,7 @@
 						<description>i2c_fifo_rdata.</description>
 						<addressOffset>0x8C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -21101,7 +21101,7 @@
 						<description>TCCR.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cs_wdt</name>
@@ -21135,7 +21135,7 @@
 						<description>TMR2_0.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tmr</name>
@@ -21149,7 +21149,7 @@
 						<description>TMR2_1.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tmr</name>
@@ -21163,7 +21163,7 @@
 						<description>TMR2_2.</description>
 						<addressOffset>0x18</addressOffset>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tmr</name>
@@ -21177,7 +21177,7 @@
 						<description>TMR3_0.</description>
 						<addressOffset>0x1C</addressOffset>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tmr</name>
@@ -21191,7 +21191,7 @@
 						<description>TMR3_1.</description>
 						<addressOffset>0x20</addressOffset>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tmr</name>
@@ -21205,7 +21205,7 @@
 						<description>TMR3_2.</description>
 						<addressOffset>0x24</addressOffset>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tmr</name>
@@ -21219,7 +21219,7 @@
 						<description>TCR2.</description>
 						<addressOffset>0x2C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -21234,7 +21234,7 @@
 						<description>TCR3.</description>
 						<addressOffset>0x30</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -21249,7 +21249,7 @@
 						<description>TMSR2.</description>
 						<addressOffset>0x38</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -21274,7 +21274,7 @@
 						<description>TMSR3.</description>
 						<addressOffset>0x3C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -21299,7 +21299,7 @@
 						<description>TIER2.</description>
 						<addressOffset>0x44</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tier_2</name>
@@ -21323,7 +21323,7 @@
 						<description>TIER3.</description>
 						<addressOffset>0x48</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tier_2</name>
@@ -21347,7 +21347,7 @@
 						<description>TPLVR2.</description>
 						<addressOffset>0x50</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tplvr</name>
@@ -21361,7 +21361,7 @@
 						<description>TPLVR3.</description>
 						<addressOffset>0x54</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tplvr</name>
@@ -21375,7 +21375,7 @@
 						<description>TPLCR2.</description>
 						<addressOffset>0x5C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tplcr</name>
@@ -21389,7 +21389,7 @@
 						<description>TPLCR3.</description>
 						<addressOffset>0x60</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tplcr</name>
@@ -21403,7 +21403,7 @@
 						<description>WMER.</description>
 						<addressOffset>0x64</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>wrie</name>
@@ -21422,7 +21422,7 @@
 						<description>WMR.</description>
 						<addressOffset>0x68</addressOffset>
 						<resetValue>0x0000ffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>wmr</name>
@@ -21436,7 +21436,7 @@
 						<description>WVR.</description>
 						<addressOffset>0x6C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -21451,7 +21451,7 @@
 						<description>WSR.</description>
 						<addressOffset>0x70</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>wts</name>
@@ -21465,7 +21465,7 @@
 						<description>TICR2.</description>
 						<addressOffset>0x78</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>write-only</access>
 						<fields>
 							<field>
@@ -21490,7 +21490,7 @@
 						<description>TICR3.</description>
 						<addressOffset>0x7C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>write-only</access>
 						<fields>
 							<field>
@@ -21515,7 +21515,7 @@
 						<description>WICR.</description>
 						<addressOffset>0x80</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>write-only</access>
 						<fields>
 							<field>
@@ -21530,7 +21530,7 @@
 						<description>TCER.</description>
 						<addressOffset>0x84</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>timer3_en</name>
@@ -21549,7 +21549,7 @@
 						<description>TCMR.</description>
 						<addressOffset>0x88</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>timer3_mode</name>
@@ -21568,7 +21568,7 @@
 						<description>TILR2.</description>
 						<addressOffset>0x90</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tilr_2</name>
@@ -21592,7 +21592,7 @@
 						<description>TILR3.</description>
 						<addressOffset>0x94</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>tilr_2</name>
@@ -21616,7 +21616,7 @@
 						<description>WCR.</description>
 						<addressOffset>0x98</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>write-only</access>
 						<fields>
 							<field>
@@ -21631,7 +21631,7 @@
 						<description>WFAR.</description>
 						<addressOffset>0x9C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>write-only</access>
 						<fields>
 							<field>
@@ -21646,7 +21646,7 @@
 						<description>WSAR.</description>
 						<addressOffset>0xA0</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>write-only</access>
 						<fields>
 							<field>
@@ -21661,7 +21661,7 @@
 						<description>TCVWR2.</description>
 						<addressOffset>0xA8</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -21676,7 +21676,7 @@
 						<description>TCVWR3.</description>
 						<addressOffset>0xAC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -21691,7 +21691,7 @@
 						<description>TCVSYN2.</description>
 						<addressOffset>0xB4</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -21706,7 +21706,7 @@
 						<description>TCVSYN3.</description>
 						<addressOffset>0xB8</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -21721,7 +21721,7 @@
 						<description>TCDR.</description>
 						<addressOffset>0xBC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>wcdr</name>
@@ -21760,7 +21760,7 @@
 						<description>irtx_config.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x0001f510</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_data_num</name>
@@ -21829,7 +21829,7 @@
 						<description>irtx_int_sts.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x01000100</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_end_en</name>
@@ -21859,7 +21859,7 @@
 						<description>irtx_data_word0.</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_data_word0</name>
@@ -21873,7 +21873,7 @@
 						<description>irtx_data_word1.</description>
 						<addressOffset>0xC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_data_word1</name>
@@ -21887,7 +21887,7 @@
 						<description>irtx_pulse_width.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x22110464</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_mod_ph1_w</name>
@@ -21911,7 +21911,7 @@
 						<description>irtx_pw.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0x007f2000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_tail_ph1_w</name>
@@ -21960,7 +21960,7 @@
 						<description>irtx_swm_pw_0.</description>
 						<addressOffset>0x40</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_0</name>
@@ -21974,7 +21974,7 @@
 						<description>irtx_swm_pw_1.</description>
 						<addressOffset>0x44</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_1</name>
@@ -21988,7 +21988,7 @@
 						<description>irtx_swm_pw_2.</description>
 						<addressOffset>0x48</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_2</name>
@@ -22002,7 +22002,7 @@
 						<description>irtx_swm_pw_3.</description>
 						<addressOffset>0x4C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_3</name>
@@ -22016,7 +22016,7 @@
 						<description>irtx_swm_pw_4.</description>
 						<addressOffset>0x50</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_4</name>
@@ -22030,7 +22030,7 @@
 						<description>irtx_swm_pw_5.</description>
 						<addressOffset>0x54</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_5</name>
@@ -22044,7 +22044,7 @@
 						<description>irtx_swm_pw_6.</description>
 						<addressOffset>0x58</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_6</name>
@@ -22058,7 +22058,7 @@
 						<description>irtx_swm_pw_7.</description>
 						<addressOffset>0x5C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_7</name>
@@ -22072,7 +22072,7 @@
 						<description>irrx_config.</description>
 						<addressOffset>0x80</addressOffset>
 						<resetValue>0x00000002</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irrx_deg_cnt</name>
@@ -22106,7 +22106,7 @@
 						<description>irrx_int_sts.</description>
 						<addressOffset>0x84</addressOffset>
 						<resetValue>0x01000100</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irrx_end_en</name>
@@ -22136,7 +22136,7 @@
 						<description>irrx_pw_config.</description>
 						<addressOffset>0x88</addressOffset>
 						<resetValue>0x23270d47</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_irrx_end_th</name>
@@ -22155,7 +22155,7 @@
 						<description>irrx_data_count.</description>
 						<addressOffset>0x90</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sts_irrx_data_cnt</name>
@@ -22170,7 +22170,7 @@
 						<description>irrx_data_word0.</description>
 						<addressOffset>0x94</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sts_irrx_data_word0</name>
@@ -22185,7 +22185,7 @@
 						<description>irrx_data_word1.</description>
 						<addressOffset>0x98</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sts_irrx_data_word1</name>
@@ -22200,7 +22200,7 @@
 						<description>irrx_swm_fifo_config_0.</description>
 						<addressOffset>0xC0</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rx_fifo_cnt</name>
@@ -22232,7 +22232,7 @@
 						<description>irrx_swm_fifo_rdata.</description>
 						<addressOffset>0xC4</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -22262,7 +22262,7 @@
 						<description>cks_config.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_cks_byte_swap</name>
@@ -22295,7 +22295,7 @@
 						<description>Checksum data in</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>data_in</name>
@@ -22310,7 +22310,7 @@
 						<description>Checksum value out</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0x0000ffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cks_out</name>
@@ -22340,7 +22340,7 @@
 						<description>sf_ctrl_0.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x1ad2001c</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_id</name>
@@ -22425,7 +22425,7 @@
 						<description>sf_ctrl_1.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0xf3600000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_ahb2sram_en</name>
@@ -22506,7 +22506,7 @@
 						<description>sf_if_sahb_0.</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_if_0_qpi_mode_en</name>
@@ -22581,7 +22581,7 @@
 						<description>sf_if_sahb_1.</description>
 						<addressOffset>0xC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_if_0_cmd_buf_0</name>
@@ -22595,7 +22595,7 @@
 						<description>sf_if_sahb_2.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_if_0_cmd_buf_1</name>
@@ -22609,7 +22609,7 @@
 						<description>sf_if_iahb_0.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0x0d040000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_if_1_qpi_mode_en</name>
@@ -22668,7 +22668,7 @@
 						<description>sf_if_iahb_1.</description>
 						<addressOffset>0x18</addressOffset>
 						<resetValue>0x03000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_if_1_cmd_buf_0</name>
@@ -22682,7 +22682,7 @@
 						<description>sf_if_iahb_2.</description>
 						<addressOffset>0x1C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_if_1_cmd_buf_1</name>
@@ -22696,7 +22696,7 @@
 						<description>sf_if_status_0.</description>
 						<addressOffset>0x20</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -22711,7 +22711,7 @@
 						<description>sf_if_status_1.</description>
 						<addressOffset>0x24</addressOffset>
 						<resetValue>0x20000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -22726,7 +22726,7 @@
 						<description>sf_aes.</description>
 						<addressOffset>0x28</addressOffset>
 						<resetValue>0x00000040</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_status</name>
@@ -22762,7 +22762,7 @@
 						<description>sf_ahb2sif_status.</description>
 						<addressOffset>0x2C</addressOffset>
 						<resetValue>0x10000003</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -22777,7 +22777,7 @@
 						<description>sf_if_io_dly_0.</description>
 						<addressOffset>0x30</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_dqs_do_dly_sel</name>
@@ -22811,7 +22811,7 @@
 						<description>sf_if_io_dly_1.</description>
 						<addressOffset>0x34</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_io_0_do_dly_sel</name>
@@ -22835,7 +22835,7 @@
 						<description>sf_if_io_dly_2.</description>
 						<addressOffset>0x38</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_io_1_do_dly_sel</name>
@@ -22859,7 +22859,7 @@
 						<description>sf_if_io_dly_3.</description>
 						<addressOffset>0x3C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_io_2_do_dly_sel</name>
@@ -22883,7 +22883,7 @@
 						<description>sf_if_io_dly_4.</description>
 						<addressOffset>0x40</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_io_3_do_dly_sel</name>
@@ -22919,7 +22919,7 @@
 						<description>sf2_if_io_dly_0.</description>
 						<addressOffset>0x48</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf2_dqs_do_dly_sel</name>
@@ -22953,7 +22953,7 @@
 						<description>sf2_if_io_dly_1.</description>
 						<addressOffset>0x4C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf2_io_0_do_dly_sel</name>
@@ -22977,7 +22977,7 @@
 						<description>sf2_if_io_dly_2.</description>
 						<addressOffset>0x50</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf2_io_1_do_dly_sel</name>
@@ -23001,7 +23001,7 @@
 						<description>sf2_if_io_dly_3.</description>
 						<addressOffset>0x54</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf2_io_2_do_dly_sel</name>
@@ -23025,7 +23025,7 @@
 						<description>sf2_if_io_dly_4.</description>
 						<addressOffset>0x58</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf2_io_3_do_dly_sel</name>
@@ -23049,7 +23049,7 @@
 						<description>sf3_if_io_dly_0.</description>
 						<addressOffset>0x5C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf3_dqs_do_dly_sel</name>
@@ -23083,7 +23083,7 @@
 						<description>sf3_if_io_dly_1.</description>
 						<addressOffset>0x60</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf3_io_0_do_dly_sel</name>
@@ -23107,7 +23107,7 @@
 						<description>sf3_if_io_dly_2.</description>
 						<addressOffset>0x64</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf3_io_1_do_dly_sel</name>
@@ -23131,7 +23131,7 @@
 						<description>sf3_if_io_dly_3.</description>
 						<addressOffset>0x68</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf3_io_2_do_dly_sel</name>
@@ -23155,7 +23155,7 @@
 						<description>sf3_if_io_dly_4.</description>
 						<addressOffset>0x6C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf3_io_3_do_dly_sel</name>
@@ -23179,7 +23179,7 @@
 						<description>sf_ctrl_2.</description>
 						<addressOffset>0x70</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_if_dqs_en</name>
@@ -23208,7 +23208,7 @@
 						<description>sf_ctrl_3.</description>
 						<addressOffset>0x74</addressOffset>
 						<resetValue>0x20000046</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_if_1_ack_lat</name>
@@ -23252,7 +23252,7 @@
 						<description>sf_if_iahb_3.</description>
 						<addressOffset>0x78</addressOffset>
 						<resetValue>0x8d840000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_if_2_qpi_mode_en</name>
@@ -23311,7 +23311,7 @@
 						<description>sf_if_iahb_4.</description>
 						<addressOffset>0x7C</addressOffset>
 						<resetValue>0x38000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_if_2_cmd_buf_0</name>
@@ -23325,7 +23325,7 @@
 						<description>sf_if_iahb_5.</description>
 						<addressOffset>0x80</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_if_2_cmd_buf_1</name>
@@ -23339,7 +23339,7 @@
 						<description>sf_if_iahb_6.</description>
 						<addressOffset>0x84</addressOffset>
 						<resetValue>0x80000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_if_3_qpi_mode_en</name>
@@ -23363,7 +23363,7 @@
 						<description>sf_if_iahb_7.</description>
 						<addressOffset>0x88</addressOffset>
 						<resetValue>0xc0000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_if_3_cmd_buf_0</name>
@@ -23377,7 +23377,7 @@
 						<description>sf_ctrl_prot_en_rd.</description>
 						<addressOffset>0x100</addressOffset>
 						<resetValue>0x00000007</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -23412,7 +23412,7 @@
 						<description>sf_ctrl_prot_en.</description>
 						<addressOffset>0x104</addressOffset>
 						<resetValue>0x00000007</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_ctrl_id1_en</name>
@@ -23436,7 +23436,7 @@
 						<description>sf_aes_key_r0_0.</description>
 						<addressOffset>0x200</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_0</name>
@@ -23450,7 +23450,7 @@
 						<description>sf_aes_key_r0_1.</description>
 						<addressOffset>0x204</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_1</name>
@@ -23464,7 +23464,7 @@
 						<description>sf_aes_key_r0_2.</description>
 						<addressOffset>0x208</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_2</name>
@@ -23478,7 +23478,7 @@
 						<description>sf_aes_key_r0_3.</description>
 						<addressOffset>0x20C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_3</name>
@@ -23492,7 +23492,7 @@
 						<description>sf_aes_key_r0_4.</description>
 						<addressOffset>0x210</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_4</name>
@@ -23506,7 +23506,7 @@
 						<description>sf_aes_key_r0_5.</description>
 						<addressOffset>0x214</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_5</name>
@@ -23520,7 +23520,7 @@
 						<description>sf_aes_key_r0_6.</description>
 						<addressOffset>0x218</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_6</name>
@@ -23534,7 +23534,7 @@
 						<description>sf_aes_key_r0_7.</description>
 						<addressOffset>0x21C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_7</name>
@@ -23548,7 +23548,7 @@
 						<description>sf_aes_iv_r0_w0.</description>
 						<addressOffset>0x220</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r0_w0</name>
@@ -23562,7 +23562,7 @@
 						<description>sf_aes_iv_r0_w1.</description>
 						<addressOffset>0x224</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r0_w1</name>
@@ -23576,7 +23576,7 @@
 						<description>sf_aes_iv_r0_w2.</description>
 						<addressOffset>0x228</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r0_w2</name>
@@ -23590,7 +23590,7 @@
 						<description>sf_aes_iv_r0_w3.</description>
 						<addressOffset>0x22C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r0_w3</name>
@@ -23604,7 +23604,7 @@
 						<description>sf_aes_cfg_r0.</description>
 						<addressOffset>0x230</addressOffset>
 						<resetValue>0x00003fff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_region_r0_lock</name>
@@ -23638,7 +23638,7 @@
 						<description>sf_aes_key_r1_0.</description>
 						<addressOffset>0x300</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_0</name>
@@ -23652,7 +23652,7 @@
 						<description>sf_aes_key_r1_1.</description>
 						<addressOffset>0x304</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_1</name>
@@ -23666,7 +23666,7 @@
 						<description>sf_aes_key_r1_2.</description>
 						<addressOffset>0x308</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_2</name>
@@ -23680,7 +23680,7 @@
 						<description>sf_aes_key_r1_3.</description>
 						<addressOffset>0x30C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_3</name>
@@ -23694,7 +23694,7 @@
 						<description>sf_aes_key_r1_4.</description>
 						<addressOffset>0x310</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_4</name>
@@ -23708,7 +23708,7 @@
 						<description>sf_aes_key_r1_5.</description>
 						<addressOffset>0x314</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_5</name>
@@ -23722,7 +23722,7 @@
 						<description>sf_aes_key_r1_6.</description>
 						<addressOffset>0x318</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_6</name>
@@ -23736,7 +23736,7 @@
 						<description>sf_aes_key_r1_7.</description>
 						<addressOffset>0x31C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_7</name>
@@ -23750,7 +23750,7 @@
 						<description>sf_aes_iv_r1_w0.</description>
 						<addressOffset>0x320</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r1_w0</name>
@@ -23764,7 +23764,7 @@
 						<description>sf_aes_iv_r1_w1.</description>
 						<addressOffset>0x324</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r1_w1</name>
@@ -23778,7 +23778,7 @@
 						<description>sf_aes_iv_r1_w2.</description>
 						<addressOffset>0x328</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r1_w2</name>
@@ -23792,7 +23792,7 @@
 						<description>sf_aes_iv_r1_w3.</description>
 						<addressOffset>0x32C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r1_w3</name>
@@ -23806,7 +23806,7 @@
 						<description>sf_aes_r1.</description>
 						<addressOffset>0x330</addressOffset>
 						<resetValue>0x00003fff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_r1_lock</name>
@@ -23840,7 +23840,7 @@
 						<description>sf_aes_key_r2_0.</description>
 						<addressOffset>0x400</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_0</name>
@@ -23854,7 +23854,7 @@
 						<description>sf_aes_key_r2_1.</description>
 						<addressOffset>0x404</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_1</name>
@@ -23868,7 +23868,7 @@
 						<description>sf_aes_key_r2_2.</description>
 						<addressOffset>0x408</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_2</name>
@@ -23882,7 +23882,7 @@
 						<description>sf_aes_key_r2_3.</description>
 						<addressOffset>0x40C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_3</name>
@@ -23896,7 +23896,7 @@
 						<description>sf_aes_key_r2_4.</description>
 						<addressOffset>0x410</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_4</name>
@@ -23910,7 +23910,7 @@
 						<description>sf_aes_key_r2_5.</description>
 						<addressOffset>0x414</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_5</name>
@@ -23924,7 +23924,7 @@
 						<description>sf_aes_key_r2_6.</description>
 						<addressOffset>0x418</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_6</name>
@@ -23938,7 +23938,7 @@
 						<description>sf_aes_key_r2_7.</description>
 						<addressOffset>0x41C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_7</name>
@@ -23952,7 +23952,7 @@
 						<description>sf_aes_iv_r2_w0.</description>
 						<addressOffset>0x420</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r2_w0</name>
@@ -23966,7 +23966,7 @@
 						<description>sf_aes_iv_r2_w1.</description>
 						<addressOffset>0x424</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r2_w1</name>
@@ -23980,7 +23980,7 @@
 						<description>sf_aes_iv_r2_w2.</description>
 						<addressOffset>0x428</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r2_w2</name>
@@ -23994,7 +23994,7 @@
 						<description>sf_aes_iv_r2_w3.</description>
 						<addressOffset>0x42C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r2_w3</name>
@@ -24008,7 +24008,7 @@
 						<description>sf_aes_r2.</description>
 						<addressOffset>0x430</addressOffset>
 						<resetValue>0x00003fff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_aes_r2_lock</name>
@@ -24042,7 +24042,7 @@
 						<description>sf_id0_offset.</description>
 						<addressOffset>0x434</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_id0_offset</name>
@@ -24056,7 +24056,7 @@
 						<description>sf_id1_offset.</description>
 						<addressOffset>0x438</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sf_id1_offset</name>
@@ -24085,7 +24085,7 @@
 						<description>DMA_IntStatus.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>IntStatus</name>
@@ -24100,7 +24100,7 @@
 						<description>DMA_IntTCStatus.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>IntTCStatus</name>
@@ -24115,7 +24115,7 @@
 						<description>DMA_IntTCClear.</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>IntTCClear</name>
@@ -24130,7 +24130,7 @@
 						<description>DMA_IntErrorStatus.</description>
 						<addressOffset>0xC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>IntErrorStatus</name>
@@ -24145,7 +24145,7 @@
 						<description>DMA_IntErrClr.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>IntErrClr</name>
@@ -24160,7 +24160,7 @@
 						<description>DMA_RawIntTCStatus.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>RawIntTCStatus</name>
@@ -24175,7 +24175,7 @@
 						<description>DMA_RawIntErrorStatus.</description>
 						<addressOffset>0x18</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>RawIntErrorStatus</name>
@@ -24190,7 +24190,7 @@
 						<description>DMA_EnbldChns.</description>
 						<addressOffset>0x1C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>EnabledChannels</name>
@@ -24205,7 +24205,7 @@
 						<description>DMA_SoftBReq.</description>
 						<addressOffset>0x20</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>SoftBReq</name>
@@ -24219,7 +24219,7 @@
 						<description>DMA_SoftSReq.</description>
 						<addressOffset>0x24</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>SoftSReq</name>
@@ -24233,7 +24233,7 @@
 						<description>DMA_SoftLBReq.</description>
 						<addressOffset>0x28</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>SoftLBReq</name>
@@ -24247,7 +24247,7 @@
 						<description>DMA_SoftLSReq.</description>
 						<addressOffset>0x2C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>SoftLSReq</name>
@@ -24261,7 +24261,7 @@
 						<description>DMA_Top_Config.</description>
 						<addressOffset>0x30</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>M</name>
@@ -24280,7 +24280,7 @@
 						<description>DMA_Sync.</description>
 						<addressOffset>0x34</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>DMA_Sync</name>
@@ -24294,7 +24294,7 @@
 						<description>DMA_C0SrcAddr.</description>
 						<addressOffset>0x100</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>SrcAddr</name>
@@ -24308,7 +24308,7 @@
 						<description>DMA_C0DstAddr.</description>
 						<addressOffset>0x104</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>DstAddr</name>
@@ -24322,7 +24322,7 @@
 						<description>DMA_C0LLI.</description>
 						<addressOffset>0x108</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>LLI</name>
@@ -24336,7 +24336,7 @@
 						<description>DMA_C0Control.</description>
 						<addressOffset>0x10C</addressOffset>
 						<resetValue>0x0c489000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>I</name>
@@ -24395,7 +24395,7 @@
 						<description>DMA_C0Config.</description>
 						<addressOffset>0x110</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>LLICounter</name>
@@ -24456,7 +24456,7 @@
 						<description>DMA_C1SrcAddr.</description>
 						<addressOffset>0x200</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>SrcAddr</name>
@@ -24470,7 +24470,7 @@
 						<description>DMA_C1DstAddr.</description>
 						<addressOffset>0x204</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>DstAddr</name>
@@ -24484,7 +24484,7 @@
 						<description>DMA_C1LLI.</description>
 						<addressOffset>0x208</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>LLI</name>
@@ -24498,7 +24498,7 @@
 						<description>DMA_C1Control.</description>
 						<addressOffset>0x20C</addressOffset>
 						<resetValue>0x0c489000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>I</name>
@@ -24552,7 +24552,7 @@
 						<description>DMA_C1Config.</description>
 						<addressOffset>0x210</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>H</name>
@@ -24607,7 +24607,7 @@
 						<description>DMA_C2SrcAddr.</description>
 						<addressOffset>0x300</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>SrcAddr</name>
@@ -24621,7 +24621,7 @@
 						<description>DMA_C2DstAddr.</description>
 						<addressOffset>0x304</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>DstAddr</name>
@@ -24635,7 +24635,7 @@
 						<description>DMA_C2LLI.</description>
 						<addressOffset>0x308</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>LLI</name>
@@ -24649,7 +24649,7 @@
 						<description>DMA_C2Control.</description>
 						<addressOffset>0x30C</addressOffset>
 						<resetValue>0x0c489000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>I</name>
@@ -24703,7 +24703,7 @@
 						<description>DMA_C2Config.</description>
 						<addressOffset>0x310</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>H</name>
@@ -24758,7 +24758,7 @@
 						<description>DMA_C3SrcAddr.</description>
 						<addressOffset>0x400</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>SrcAddr</name>
@@ -24772,7 +24772,7 @@
 						<description>DMA_C3DstAddr.</description>
 						<addressOffset>0x404</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>DstAddr</name>
@@ -24786,7 +24786,7 @@
 						<description>DMA_C3LLI.</description>
 						<addressOffset>0x408</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>LLI</name>
@@ -24800,7 +24800,7 @@
 						<description>DMA_C3Control.</description>
 						<addressOffset>0x40C</addressOffset>
 						<resetValue>0x0c489000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>I</name>
@@ -24854,7 +24854,7 @@
 						<description>DMA_C3Config.</description>
 						<addressOffset>0x410</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>H</name>
@@ -24924,7 +24924,7 @@
 						<description>PDS_CTL.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x1a006b00</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_pds_ctrl_pll</name>
@@ -25038,7 +25038,7 @@
 						<description>PDS_TIME1.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x00000ca8</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_sleep_duration</name>
@@ -25052,7 +25052,7 @@
 						<description>PDS_INT.</description>
 						<addressOffset>0xC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_pds_int_clr</name>
@@ -25110,7 +25110,7 @@
 						<description>PDS_CTL2.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_pds_force_wb_gate_clk</name>
@@ -25169,7 +25169,7 @@
 						<description>PDS_CTL3.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0x49000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_pds_misc_iso_en</name>
@@ -25218,7 +25218,7 @@
 						<description>PDS_CTL4.</description>
 						<addressOffset>0x18</addressOffset>
 						<resetValue>0x0f00f00f</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_pds_misc_gate_clk</name>
@@ -25287,7 +25287,7 @@
 						<description>pds_stat.</description>
 						<addressOffset>0x1C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -25312,7 +25312,7 @@
 						<description>pds_ram1.</description>
 						<addressOffset>0x20</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>cr_np_sram_pwr</name>
@@ -25326,7 +25326,7 @@
 						<description>rc32m_ctrl0.</description>
 						<addressOffset>0x300</addressOffset>
 						<resetValue>0x18080018</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rc32m_code_fr_ext</name>
@@ -25400,7 +25400,7 @@
 						<description>rc32m_ctrl1.</description>
 						<addressOffset>0x304</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rc32m_reserved</name>
@@ -25439,7 +25439,7 @@
 						<description>pu_rst_clkpll.</description>
 						<addressOffset>0x400</addressOffset>
 						<resetValue>0x000001f0</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pu_clkpll</name>
@@ -25503,7 +25503,7 @@
 						<description>clkpll_top_ctrl.</description>
 						<addressOffset>0x404</addressOffset>
 						<resetValue>0x01100414</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>clkpll_vg13_sel</name>
@@ -25542,7 +25542,7 @@
 						<description>clkpll_cp.</description>
 						<addressOffset>0x408</addressOffset>
 						<resetValue>0x00000741</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>clkpll_cp_opamp_en</name>
@@ -25581,7 +25581,7 @@
 						<description>clkpll_rz.</description>
 						<addressOffset>0x40C</addressOffset>
 						<resetValue>0x0005a020</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>clkpll_rz</name>
@@ -25620,7 +25620,7 @@
 						<description>clkpll_fbdv.</description>
 						<addressOffset>0x410</addressOffset>
 						<resetValue>0x00000005</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>clkpll_sel_fb_clk</name>
@@ -25639,7 +25639,7 @@
 						<description>clkpll_vco.</description>
 						<addressOffset>0x414</addressOffset>
 						<resetValue>0x00000007</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>clkpll_shrtr</name>
@@ -25658,7 +25658,7 @@
 						<description>clkpll_sdm.</description>
 						<addressOffset>0x418</addressOffset>
 						<resetValue>0x10600000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>clkpll_sdm_bypass</name>
@@ -25687,7 +25687,7 @@
 						<description>clkpll_output_en.</description>
 						<addressOffset>0x41C</addressOffset>
 						<resetValue>0x00000100</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>clkpll_en_div2_480m</name>
@@ -25761,7 +25761,7 @@
 						<description>HBN_CTL.</description>
 						<addressOffset>0x0</addressOffset>
 						<resetValue>0x00d50000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>hbn_state</name>
@@ -25854,7 +25854,7 @@
 						<description>HBN_TIME_L.</description>
 						<addressOffset>0x4</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>hbn_time_l</name>
@@ -25868,7 +25868,7 @@
 						<description>HBN_TIME_H.</description>
 						<addressOffset>0x8</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>hbn_time_h</name>
@@ -25882,7 +25882,7 @@
 						<description>RTC_TIME_L.</description>
 						<addressOffset>0xC</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -25897,7 +25897,7 @@
 						<description>RTC_TIME_H.</description>
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rtc_time_latch</name>
@@ -25918,7 +25918,7 @@
 						<description>HBN_IRQ_MODE.</description>
 						<addressOffset>0x14</addressOffset>
 						<resetValue>0x03010105</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pin_wakeup_en</name>
@@ -25972,7 +25972,7 @@
 						<description>HBN_IRQ_STAT.</description>
 						<addressOffset>0x18</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>read-only</access>
 						<fields>
 							<field>
@@ -25987,7 +25987,7 @@
 						<description>HBN_IRQ_CLR.</description>
 						<addressOffset>0x1C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<access>write-only</access>
 						<fields>
 							<field>
@@ -26002,7 +26002,7 @@
 						<description>HBN_PIR_CFG.</description>
 						<addressOffset>0x20</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_nosync</name>
@@ -26041,7 +26041,7 @@
 						<description>HBN_PIR_VTH.</description>
 						<addressOffset>0x24</addressOffset>
 						<resetValue>0x000003ff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pir_vth</name>
@@ -26055,7 +26055,7 @@
 						<description>HBN_PIR_INTERVAL.</description>
 						<addressOffset>0x28</addressOffset>
 						<resetValue>0x00000a3d</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pir_interval</name>
@@ -26069,7 +26069,7 @@
 						<description>HBN_BOR_CFG.</description>
 						<addressOffset>0x2C</addressOffset>
 						<resetValue>0x00000002</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>r_bor_out</name>
@@ -26099,7 +26099,7 @@
 						<description>HBN_GLB.</description>
 						<addressOffset>0x30</addressOffset>
 						<resetValue>0xaa0a0020</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sw_ldo11_aon_vout_sel</name>
@@ -26143,7 +26143,7 @@
 						<description>HBN_SRAM.</description>
 						<addressOffset>0x34</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>retram_slp</name>
@@ -26162,7 +26162,7 @@
 						<description>HBN_RSV0.</description>
 						<addressOffset>0x100</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>HBN_RSV0</name>
@@ -26176,7 +26176,7 @@
 						<description>HBN_RSV1.</description>
 						<addressOffset>0x104</addressOffset>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>HBN_RSV1</name>
@@ -26190,7 +26190,7 @@
 						<description>HBN_RSV2.</description>
 						<addressOffset>0x108</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>HBN_RSV2</name>
@@ -26204,7 +26204,7 @@
 						<description>HBN_RSV3.</description>
 						<addressOffset>0x10C</addressOffset>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>HBN_RSV3</name>
@@ -26218,7 +26218,7 @@
 						<description>rc32k_ctrl0.</description>
 						<addressOffset>0x200</addressOffset>
 						<resetValue>0x5008801b</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>rc32k_code_fr_ext</name>
@@ -26287,7 +26287,7 @@
 						<description>xtal32k.</description>
 						<addressOffset>0x204</addressOffset>
 						<resetValue>0x000f0228</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pu_xtal32k</name>
@@ -26361,7 +26361,7 @@
 						<description>aon.</description>
 						<addressOffset>0x000</addressOffset>
 						<resetValue>0x00400000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sw_pu_ldo11_rt</name>
@@ -26395,7 +26395,7 @@
 						<description>aon_common.</description>
 						<addressOffset>0x004</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ten_cip_misc_aon</name>
@@ -26474,7 +26474,7 @@
 						<description>aon_misc.</description>
 						<addressOffset>0x008</addressOffset>
 						<resetValue>0x00000003</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>sw_wb_en_aon</name>
@@ -26493,7 +26493,7 @@
 						<description>bg_sys_top.</description>
 						<addressOffset>0x010</addressOffset>
 						<resetValue>0x00001100</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>bg_sys_start_ctrl_aon</name>
@@ -26517,7 +26517,7 @@
 						<description>dcdc18_top_0.</description>
 						<addressOffset>0x014</addressOffset>
 						<resetValue>0x8a580736</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>dcdc18_rdy_aon</name>
@@ -26577,7 +26577,7 @@
 						<description>dcdc18_top_1.</description>
 						<addressOffset>0x018</addressOffset>
 						<resetValue>0x18180048</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>dcdc18_pulldown_aon</name>
@@ -26631,7 +26631,7 @@
 						<description>ldo11soc_and_dctest.</description>
 						<addressOffset>0x01C</addressOffset>
 						<resetValue>0x70001811</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pmip_dc_tp_out_en_aon</name>
@@ -26697,7 +26697,7 @@
 						<description>psw_irrcv.</description>
 						<addressOffset>0x020</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pu_ir_psw_aon</name>
@@ -26711,7 +26711,7 @@
 						<description>rf_top_aon.</description>
 						<addressOffset>0x080</addressOffset>
 						<resetValue>0x00020137</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>ldo15rf_bypass_aon</name>
@@ -26780,7 +26780,7 @@
 						<description>xtal_cfg.</description>
 						<addressOffset>0x084</addressOffset>
 						<resetValue>0xb410f0f0</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>xtal_rdy_sel_aon</name>
@@ -26849,7 +26849,7 @@
 						<description>tsen.</description>
 						<addressOffset>0x088</addressOffset>
 						<resetValue>0x78ff08ff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>xtal_rdy_int_sel_aon</name>
@@ -26884,7 +26884,7 @@
 						<description>acomp0_ctrl.</description>
 						<addressOffset>0x100</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>acomp0_muxen</name>
@@ -26933,7 +26933,7 @@
 						<description>acomp1_ctrl.</description>
 						<addressOffset>0x104</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>acomp1_muxen</name>
@@ -26982,7 +26982,7 @@
 						<description>acomp_ctrl.</description>
 						<addressOffset>0x108</addressOffset>
 						<resetValue>0x00000003</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>acomp_reserved</name>
@@ -27038,7 +27038,7 @@
 						<description>gpadc_reg_cmd.</description>
 						<addressOffset>0x10C</addressOffset>
 						<resetValue>0x00000f78</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_sen_test_en</name>
@@ -27132,7 +27132,7 @@
 						<description>gpadc_reg_config1.</description>
 						<addressOffset>0x110</addressOffset>
 						<resetValue>0x000c0002</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_v18_sel</name>
@@ -27191,7 +27191,7 @@
 						<description>gpadc_reg_config2.</description>
 						<addressOffset>0x114</addressOffset>
 						<resetValue>0x00019100</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_tsvbe_low</name>
@@ -27285,7 +27285,7 @@
 						<description>adc converation sequence 1</description>
 						<addressOffset>0x118</addressOffset>
 						<resetValue>0x1ef7bdef</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_scan_pos_5</name>
@@ -27324,7 +27324,7 @@
 						<description>adc converation sequence 2</description>
 						<addressOffset>0x11C</addressOffset>
 						<resetValue>0x1ef7bdef</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_scan_pos_11</name>
@@ -27363,7 +27363,7 @@
 						<description>adc converation sequence 3</description>
 						<addressOffset>0x120</addressOffset>
 						<resetValue>0x1ef7bdef</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_scan_neg_5</name>
@@ -27402,7 +27402,7 @@
 						<description>adc converation sequence 4</description>
 						<addressOffset>0x124</addressOffset>
 						<resetValue>0x1ef7bdef</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_scan_neg_11</name>
@@ -27441,7 +27441,7 @@
 						<description>gpadc_reg_status.</description>
 						<addressOffset>0x128</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_reserved</name>
@@ -27461,7 +27461,7 @@
 						<description>gpadc_reg_isr.</description>
 						<addressOffset>0x12C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_pos_satur_mask</name>
@@ -27502,7 +27502,7 @@
 						<description>gpadc_reg_result.</description>
 						<addressOffset>0x130</addressOffset>
 						<resetValue>0x01ef0000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_data_out</name>
@@ -27517,7 +27517,7 @@
 						<description>gpadc_reg_raw_result.</description>
 						<addressOffset>0x134</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_raw_data</name>
@@ -27532,7 +27532,7 @@
 						<description>gpadc_reg_define.</description>
 						<addressOffset>0x138</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>gpadc_os_cal_data</name>
@@ -27546,7 +27546,7 @@
 						<description>hbncore_resv0.</description>
 						<addressOffset>0x13C</addressOffset>
 						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>hbncore_resv0_data</name>
@@ -27560,7 +27560,7 @@
 						<description>hbncore_resv1.</description>
 						<addressOffset>0x140</addressOffset>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0xffffffff</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>hbncore_resv1_data</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -14992,6 +14992,8 @@
 						<name>irtx_config</name>
 						<description>irtx_config.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x0001f510</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_data_num</name>
@@ -15059,6 +15061,8 @@
 						<name>irtx_int_sts</name>
 						<description>irtx_int_sts.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x01000100</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_end_en</name>
@@ -15079,6 +15083,7 @@
 								<name>irtx_end_int</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -15086,6 +15091,8 @@
 						<name>irtx_data_word0</name>
 						<description>irtx_data_word0.</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_data_word0</name>
@@ -15098,6 +15105,8 @@
 						<name>irtx_data_word1</name>
 						<description>irtx_data_word1.</description>
 						<addressOffset>0xC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_data_word1</name>
@@ -15110,6 +15119,8 @@
 						<name>irtx_pulse_width</name>
 						<description>irtx_pulse_width.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x22110464</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_mod_ph1_w</name>
@@ -15132,6 +15143,8 @@
 						<name>irtx_pw</name>
 						<description>irtx_pw.</description>
 						<addressOffset>0x14</addressOffset>
+						<resetValue>0x007f2000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_tail_ph1_w</name>
@@ -15179,6 +15192,8 @@
 						<name>irtx_swm_pw_0</name>
 						<description>irtx_swm_pw_0.</description>
 						<addressOffset>0x40</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_0</name>
@@ -15191,6 +15206,8 @@
 						<name>irtx_swm_pw_1</name>
 						<description>irtx_swm_pw_1.</description>
 						<addressOffset>0x44</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_1</name>
@@ -15203,6 +15220,8 @@
 						<name>irtx_swm_pw_2</name>
 						<description>irtx_swm_pw_2.</description>
 						<addressOffset>0x48</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_2</name>
@@ -15215,6 +15234,8 @@
 						<name>irtx_swm_pw_3</name>
 						<description>irtx_swm_pw_3.</description>
 						<addressOffset>0x4C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_3</name>
@@ -15227,6 +15248,8 @@
 						<name>irtx_swm_pw_4</name>
 						<description>irtx_swm_pw_4.</description>
 						<addressOffset>0x50</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_4</name>
@@ -15239,6 +15262,8 @@
 						<name>irtx_swm_pw_5</name>
 						<description>irtx_swm_pw_5.</description>
 						<addressOffset>0x54</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_5</name>
@@ -15251,6 +15276,8 @@
 						<name>irtx_swm_pw_6</name>
 						<description>irtx_swm_pw_6.</description>
 						<addressOffset>0x58</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_6</name>
@@ -15263,6 +15290,8 @@
 						<name>irtx_swm_pw_7</name>
 						<description>irtx_swm_pw_7.</description>
 						<addressOffset>0x5C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irtx_swm_pw_7</name>
@@ -15275,6 +15304,8 @@
 						<name>irrx_config</name>
 						<description>irrx_config.</description>
 						<addressOffset>0x80</addressOffset>
+						<resetValue>0x00000002</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irrx_deg_cnt</name>
@@ -15307,6 +15338,8 @@
 						<name>irrx_int_sts</name>
 						<description>irrx_int_sts.</description>
 						<addressOffset>0x84</addressOffset>
+						<resetValue>0x01000100</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irrx_end_en</name>
@@ -15327,6 +15360,7 @@
 								<name>irrx_end_int</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -15334,6 +15368,8 @@
 						<name>irrx_pw_config</name>
 						<description>irrx_pw_config.</description>
 						<addressOffset>0x88</addressOffset>
+						<resetValue>0x23270d47</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_irrx_end_th</name>
@@ -15351,11 +15387,14 @@
 						<name>irrx_data_count</name>
 						<description>irrx_data_count.</description>
 						<addressOffset>0x90</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sts_irrx_data_cnt</name>
 								<lsb>0</lsb>
 								<msb>6</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -15363,11 +15402,14 @@
 						<name>irrx_data_word0</name>
 						<description>irrx_data_word0.</description>
 						<addressOffset>0x94</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sts_irrx_data_word0</name>
 								<lsb>0</lsb>
 								<msb>31</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -15375,11 +15417,14 @@
 						<name>irrx_data_word1</name>
 						<description>irrx_data_word1.</description>
 						<addressOffset>0x98</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sts_irrx_data_word1</name>
 								<lsb>0</lsb>
 								<msb>31</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -15387,6 +15432,8 @@
 						<name>irrx_swm_fifo_config_0</name>
 						<description>irrx_swm_fifo_config_0.</description>
 						<addressOffset>0xC0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rx_fifo_cnt</name>
@@ -15415,6 +15462,9 @@
 						<name>irrx_swm_fifo_rdata</name>
 						<description>irrx_swm_fifo_rdata.</description>
 						<addressOffset>0xC4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>rx_fifo_rdata</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -13579,6 +13579,9 @@
 						<name>spi_fifo_wdata</name>
 						<description>spi_fifo_wdata.</description>
 						<addressOffset>0x88</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>write-only</access>
 						<fields>
 							<field>
 								<name>spi_fifo_wdata</name>
@@ -13591,6 +13594,9 @@
 						<name>spi_fifo_rdata</name>
 						<description>spi_fifo_rdata.</description>
 						<addressOffset>0x8C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>spi_fifo_rdata</name>
@@ -14708,6 +14714,8 @@
 						<name>TCCR</name>
 						<description>TCCR.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cs_wdt</name>
@@ -14740,6 +14748,8 @@
 						<name>TMR2_0</name>
 						<description>TMR2_0.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tmr</name>
@@ -14752,6 +14762,8 @@
 						<name>TMR2_1</name>
 						<description>TMR2_1.</description>
 						<addressOffset>0x14</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tmr</name>
@@ -14764,6 +14776,8 @@
 						<name>TMR2_2</name>
 						<description>TMR2_2.</description>
 						<addressOffset>0x18</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tmr</name>
@@ -14776,6 +14790,8 @@
 						<name>TMR3_0</name>
 						<description>TMR3_0.</description>
 						<addressOffset>0x1C</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tmr</name>
@@ -14788,6 +14804,8 @@
 						<name>TMR3_1</name>
 						<description>TMR3_1.</description>
 						<addressOffset>0x20</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tmr</name>
@@ -14800,6 +14818,8 @@
 						<name>TMR3_2</name>
 						<description>TMR3_2.</description>
 						<addressOffset>0x24</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tmr</name>
@@ -14812,6 +14832,9 @@
 						<name>TCR2</name>
 						<description>TCR2.</description>
 						<addressOffset>0x2C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tcr</name>
@@ -14824,6 +14847,9 @@
 						<name>TCR3</name>
 						<description>TCR3.</description>
 						<addressOffset>0x30</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tcr3_counter</name>
@@ -14836,6 +14862,9 @@
 						<name>TMSR2</name>
 						<description>TMSR2.</description>
 						<addressOffset>0x38</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tmsr_2</name>
@@ -14858,6 +14887,9 @@
 						<name>TMSR3</name>
 						<description>TMSR3.</description>
 						<addressOffset>0x3C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tmsr_2</name>
@@ -14880,6 +14912,8 @@
 						<name>TIER2</name>
 						<description>TIER2.</description>
 						<addressOffset>0x44</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tier_2</name>
@@ -14902,6 +14936,8 @@
 						<name>TIER3</name>
 						<description>TIER3.</description>
 						<addressOffset>0x48</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tier_2</name>
@@ -14924,6 +14960,8 @@
 						<name>TPLVR2</name>
 						<description>TPLVR2.</description>
 						<addressOffset>0x50</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tplvr</name>
@@ -14936,6 +14974,8 @@
 						<name>TPLVR3</name>
 						<description>TPLVR3.</description>
 						<addressOffset>0x54</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tplvr</name>
@@ -14948,6 +14988,8 @@
 						<name>TPLCR2</name>
 						<description>TPLCR2.</description>
 						<addressOffset>0x5C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tplcr</name>
@@ -14960,6 +15002,8 @@
 						<name>TPLCR3</name>
 						<description>TPLCR3.</description>
 						<addressOffset>0x60</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tplcr</name>
@@ -14972,6 +15016,8 @@
 						<name>WMER</name>
 						<description>WMER.</description>
 						<addressOffset>0x64</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>wrie</name>
@@ -14989,6 +15035,8 @@
 						<name>WMR</name>
 						<description>WMR.</description>
 						<addressOffset>0x68</addressOffset>
+						<resetValue>0x0000ffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>wmr</name>
@@ -15001,6 +15049,9 @@
 						<name>WVR</name>
 						<description>WVR.</description>
 						<addressOffset>0x6C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>wvr</name>
@@ -15013,6 +15064,8 @@
 						<name>WSR</name>
 						<description>WSR.</description>
 						<addressOffset>0x70</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>wts</name>
@@ -15025,6 +15078,9 @@
 						<name>TICR2</name>
 						<description>TICR2.</description>
 						<addressOffset>0x78</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>write-only</access>
 						<fields>
 							<field>
 								<name>tclr_2</name>
@@ -15047,6 +15103,9 @@
 						<name>TICR3</name>
 						<description>TICR3.</description>
 						<addressOffset>0x7C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>write-only</access>
 						<fields>
 							<field>
 								<name>tclr_2</name>
@@ -15069,6 +15128,9 @@
 						<name>WICR</name>
 						<description>WICR.</description>
 						<addressOffset>0x80</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>write-only</access>
 						<fields>
 							<field>
 								<name>wiclr</name>
@@ -15081,6 +15143,8 @@
 						<name>TCER</name>
 						<description>TCER.</description>
 						<addressOffset>0x84</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>timer3_en</name>
@@ -15098,6 +15162,8 @@
 						<name>TCMR</name>
 						<description>TCMR.</description>
 						<addressOffset>0x88</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>timer3_mode</name>
@@ -15115,6 +15181,8 @@
 						<name>TILR2</name>
 						<description>TILR2.</description>
 						<addressOffset>0x90</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tilr_2</name>
@@ -15137,6 +15205,8 @@
 						<name>TILR3</name>
 						<description>TILR3.</description>
 						<addressOffset>0x94</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tilr_2</name>
@@ -15159,6 +15229,9 @@
 						<name>WCR</name>
 						<description>WCR.</description>
 						<addressOffset>0x98</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>write-only</access>
 						<fields>
 							<field>
 								<name>wcr</name>
@@ -15171,6 +15244,9 @@
 						<name>WFAR</name>
 						<description>WFAR.</description>
 						<addressOffset>0x9C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>write-only</access>
 						<fields>
 							<field>
 								<name>wfar</name>
@@ -15183,6 +15259,9 @@
 						<name>WSAR</name>
 						<description>WSAR.</description>
 						<addressOffset>0xA0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>write-only</access>
 						<fields>
 							<field>
 								<name>wsar</name>
@@ -15195,6 +15274,9 @@
 						<name>TCVWR2</name>
 						<description>TCVWR2.</description>
 						<addressOffset>0xA8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tcvwr</name>
@@ -15207,6 +15289,9 @@
 						<name>TCVWR3</name>
 						<description>TCVWR3.</description>
 						<addressOffset>0xAC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tcvwr</name>
@@ -15219,6 +15304,9 @@
 						<name>TCVSYN2</name>
 						<description>TCVSYN2.</description>
 						<addressOffset>0xB4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tcvsyn2</name>
@@ -15231,6 +15319,9 @@
 						<name>TCVSYN3</name>
 						<description>TCVSYN3.</description>
 						<addressOffset>0xB8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tcvsyn3</name>
@@ -15243,6 +15334,8 @@
 						<name>TCDR</name>
 						<description>TCDR.</description>
 						<addressOffset>0xBC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>wcdr</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -10944,6 +10944,8 @@
 						<name>reg_key_slot_6_w0</name>
 						<description>reg_key_slot_6_w0.</description>
 						<addressOffset>0x80</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_6_w0</name>
@@ -10956,6 +10958,8 @@
 						<name>reg_key_slot_6_w1</name>
 						<description>reg_key_slot_6_w1.</description>
 						<addressOffset>0x84</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_6_w1</name>
@@ -10968,6 +10972,8 @@
 						<name>reg_key_slot_6_w2</name>
 						<description>reg_key_slot_6_w2.</description>
 						<addressOffset>0x88</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_6_w2</name>
@@ -10980,6 +10986,8 @@
 						<name>reg_key_slot_6_w3</name>
 						<description>reg_key_slot_6_w3.</description>
 						<addressOffset>0x8C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_6_w3</name>
@@ -10992,6 +11000,8 @@
 						<name>reg_key_slot_7_w0</name>
 						<description>reg_key_slot_7_w0.</description>
 						<addressOffset>0x90</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_7_w0</name>
@@ -11004,6 +11014,8 @@
 						<name>reg_key_slot_7_w1</name>
 						<description>reg_key_slot_7_w1.</description>
 						<addressOffset>0x94</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_7_w1</name>
@@ -11016,6 +11028,8 @@
 						<name>reg_key_slot_7_w2</name>
 						<description>reg_key_slot_7_w2.</description>
 						<addressOffset>0x98</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_7_w2</name>
@@ -11028,6 +11042,8 @@
 						<name>reg_key_slot_7_w3</name>
 						<description>reg_key_slot_7_w3.</description>
 						<addressOffset>0x9C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_7_w3</name>
@@ -11040,6 +11056,8 @@
 						<name>reg_key_slot_8_w0</name>
 						<description>reg_key_slot_8_w0.</description>
 						<addressOffset>0xA0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_8_w0</name>
@@ -11052,6 +11070,8 @@
 						<name>reg_key_slot_8_w1</name>
 						<description>reg_key_slot_8_w1.</description>
 						<addressOffset>0xA4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_8_w1</name>
@@ -11064,6 +11084,8 @@
 						<name>reg_key_slot_8_w2</name>
 						<description>reg_key_slot_8_w2.</description>
 						<addressOffset>0xA8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_8_w2</name>
@@ -11076,6 +11098,8 @@
 						<name>reg_key_slot_8_w3</name>
 						<description>reg_key_slot_8_w3.</description>
 						<addressOffset>0xAC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_8_w3</name>
@@ -11088,6 +11112,8 @@
 						<name>reg_key_slot_9_w0</name>
 						<description>reg_key_slot_9_w0.</description>
 						<addressOffset>0xB0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_9_w0</name>
@@ -11100,6 +11126,8 @@
 						<name>reg_key_slot_9_w1</name>
 						<description>reg_key_slot_9_w1.</description>
 						<addressOffset>0xB4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_9_w1</name>
@@ -11112,6 +11140,8 @@
 						<name>reg_key_slot_9_w2</name>
 						<description>reg_key_slot_9_w2.</description>
 						<addressOffset>0xB8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_9_w2</name>
@@ -11124,6 +11154,8 @@
 						<name>reg_key_slot_9_w3</name>
 						<description>reg_key_slot_9_w3.</description>
 						<addressOffset>0xBC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>reg_key_slot_9_w3</name>
@@ -11136,54 +11168,72 @@
 						<name>reg_key_slot_10_w0</name>
 						<description>reg_key_slot_10_w0.</description>
 						<addressOffset>0xC0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_10_w1</name>
 						<description>reg_key_slot_10_w1.</description>
 						<addressOffset>0xC4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_10_w2</name>
 						<description>reg_key_slot_10_w2.</description>
 						<addressOffset>0xC8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_10_w3</name>
 						<description>reg_key_slot_10_w3.</description>
 						<addressOffset>0xCC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_11_w0</name>
 						<description>reg_key_slot_11_w0.</description>
 						<addressOffset>0xD0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_11_w1</name>
 						<description>reg_key_slot_11_w1.</description>
 						<addressOffset>0xD4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_11_w2</name>
 						<description>reg_key_slot_11_w2.</description>
 						<addressOffset>0xD8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_11_w3</name>
 						<description>reg_key_slot_11_w3.</description>
 						<addressOffset>0xDC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields/>
 					</register>
 					<register>
 						<name>reg_data_1_lock</name>
 						<description>reg_data_1_lock.</description>
 						<addressOffset>0xE0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rd_lock_key_slot_9</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -10452,6 +10452,9 @@
 						<name>tzc_rom_ctrl</name>
 						<description>tzc_rom_ctrl.</description>
 						<addressOffset>0x40</addressOffset>
+						<resetValue>0x00000f0f</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tzc_sboot_done</name>
@@ -10544,6 +10547,9 @@
 						<name>tzc_rom0_r0</name>
 						<description>tzc_rom0_r0.</description>
 						<addressOffset>0x44</addressOffset>
+						<resetValue>0x0000ffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tzc_rom0_r0_start</name>
@@ -10561,6 +10567,9 @@
 						<name>tzc_rom0_r1</name>
 						<description>tzc_rom0_r1.</description>
 						<addressOffset>0x48</addressOffset>
+						<resetValue>0x0000ffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tzc_rom0_r1_start</name>
@@ -10578,6 +10587,9 @@
 						<name>tzc_rom1_r0</name>
 						<description>tzc_rom1_r0.</description>
 						<addressOffset>0x4C</addressOffset>
+						<resetValue>0x0000ffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tzc_rom1_r0_start</name>
@@ -10595,6 +10607,9 @@
 						<name>tzc_rom1_r1</name>
 						<description>tzc_rom1_r1.</description>
 						<addressOffset>0x50</addressOffset>
+						<resetValue>0x0000ffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>tzc_rom1_r1_start</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -18854,6 +18854,8 @@
 						<name>aon</name>
 						<description>aon.</description>
 						<addressOffset>0x800</addressOffset>
+						<resetValue>0x00400000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sw_pu_ldo11_rt</name>
@@ -18886,6 +18888,8 @@
 						<name>aon_common</name>
 						<description>aon_common.</description>
 						<addressOffset>0x804</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ten_cip_misc_aon</name>
@@ -18963,6 +18967,8 @@
 						<name>aon_misc</name>
 						<description>aon_misc.</description>
 						<addressOffset>0x808</addressOffset>
+						<resetValue>0x00000003</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sw_wb_en_aon</name>
@@ -18980,6 +18986,8 @@
 						<name>bg_sys_top</name>
 						<description>bg_sys_top.</description>
 						<addressOffset>0x810</addressOffset>
+						<resetValue>0x00001100</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>bg_sys_start_ctrl_aon</name>
@@ -19002,11 +19010,14 @@
 						<name>dcdc18_top_0</name>
 						<description>dcdc18_top_0.</description>
 						<addressOffset>0x814</addressOffset>
+						<resetValue>0x8a580736</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>dcdc18_rdy_aon</name>
 								<lsb>31</lsb>
 								<msb>31</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>dcdc18_sstart_time_aon</name>
@@ -19059,6 +19070,8 @@
 						<name>dcdc18_top_1</name>
 						<description>dcdc18_top_1.</description>
 						<addressOffset>0x818</addressOffset>
+						<resetValue>0x18180048</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>dcdc18_pulldown_aon</name>
@@ -19111,6 +19124,8 @@
 						<name>ldo11soc_and_dctest</name>
 						<description>ldo11soc_and_dctest.</description>
 						<addressOffset>0x81C</addressOffset>
+						<resetValue>0x70001811</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>pmip_dc_tp_out_en_aon</name>
@@ -19126,11 +19141,13 @@
 								<name>ldo11soc_power_good_aon</name>
 								<lsb>29</lsb>
 								<msb>29</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>ldo11soc_rdy_aon</name>
 								<lsb>28</lsb>
 								<msb>28</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>ldo11soc_cc_aon</name>
@@ -19173,6 +19190,8 @@
 						<name>psw_irrcv</name>
 						<description>psw_irrcv.</description>
 						<addressOffset>0x820</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>pu_ir_psw_aon</name>
@@ -19185,6 +19204,8 @@
 						<name>rf_top_aon</name>
 						<description>rf_top_aon.</description>
 						<addressOffset>0x880</addressOffset>
+						<resetValue>0x00020137</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>ldo15rf_bypass_aon</name>
@@ -19252,6 +19273,8 @@
 						<name>xtal_cfg</name>
 						<description>xtal_cfg.</description>
 						<addressOffset>0x884</addressOffset>
+						<resetValue>0xb410f0f0</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>xtal_rdy_sel_aon</name>
@@ -19319,6 +19342,8 @@
 						<name>tsen</name>
 						<description>tsen.</description>
 						<addressOffset>0x888</addressOffset>
+						<resetValue>0x78ff08ff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>xtal_rdy_int_sel_aon</name>
@@ -19334,6 +19359,7 @@
 								<name>xtal_rdy</name>
 								<lsb>28</lsb>
 								<msb>28</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>tsen_refcode_rfcal</name>
@@ -19351,6 +19377,8 @@
 						<name>acomp0_ctrl</name>
 						<description>acomp0_ctrl.</description>
 						<addressOffset>0x900</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>acomp0_muxen</name>
@@ -19398,6 +19426,8 @@
 						<name>acomp1_ctrl</name>
 						<description>acomp1_ctrl.</description>
 						<addressOffset>0x904</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>acomp1_muxen</name>
@@ -19445,6 +19475,8 @@
 						<name>acomp_ctrl</name>
 						<description>acomp_ctrl.</description>
 						<addressOffset>0x908</addressOffset>
+						<resetValue>0x00000003</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>acomp_reserved</name>
@@ -19455,11 +19487,13 @@
 								<name>acomp0_out_raw</name>
 								<lsb>19</lsb>
 								<msb>19</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>acomp1_out_raw</name>
 								<lsb>17</lsb>
 								<msb>17</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>acomp0_test_sel</name>
@@ -19497,6 +19531,8 @@
 						<name>gpadc_reg_cmd</name>
 						<description>gpadc_reg_cmd.</description>
 						<addressOffset>0x90C</addressOffset>
+						<resetValue>0x00000f78</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_sen_test_en</name>
@@ -19589,6 +19625,8 @@
 						<name>gpadc_reg_config1</name>
 						<description>gpadc_reg_config1.</description>
 						<addressOffset>0x910</addressOffset>
+						<resetValue>0x000c0002</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_v18_sel</name>
@@ -19646,6 +19684,8 @@
 						<name>gpadc_reg_config2</name>
 						<description>gpadc_reg_config2.</description>
 						<addressOffset>0x914</addressOffset>
+						<resetValue>0x00019100</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_tsvbe_low</name>
@@ -19738,6 +19778,8 @@
 						<name>gpadc_reg_scn_pos1</name>
 						<description>adc converation sequence 1</description>
 						<addressOffset>0x918</addressOffset>
+						<resetValue>0x1ef7bdef</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_scan_pos_5</name>
@@ -19775,6 +19817,8 @@
 						<name>gpadc_reg_scn_pos2</name>
 						<description>adc converation sequence 2</description>
 						<addressOffset>0x91C</addressOffset>
+						<resetValue>0x1ef7bdef</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_scan_pos_11</name>
@@ -19812,6 +19856,8 @@
 						<name>gpadc_reg_scn_neg1</name>
 						<description>adc converation sequence 3</description>
 						<addressOffset>0x920</addressOffset>
+						<resetValue>0x1ef7bdef</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_scan_neg_5</name>
@@ -19849,6 +19895,8 @@
 						<name>gpadc_reg_scn_neg2</name>
 						<description>adc converation sequence 4</description>
 						<addressOffset>0x924</addressOffset>
+						<resetValue>0x1ef7bdef</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_scan_neg_11</name>
@@ -19886,6 +19934,8 @@
 						<name>gpadc_reg_status</name>
 						<description>gpadc_reg_status.</description>
 						<addressOffset>0x928</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_reserved</name>
@@ -19896,6 +19946,7 @@
 								<name>gpadc_data_rdy</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -19903,6 +19954,8 @@
 						<name>gpadc_reg_isr</name>
 						<description>gpadc_reg_isr.</description>
 						<addressOffset>0x92C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_pos_satur_mask</name>
@@ -19928,11 +19981,13 @@
 								<name>gpadc_pos_satur</name>
 								<lsb>1</lsb>
 								<msb>1</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>gpadc_neg_satur</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -19940,11 +19995,14 @@
 						<name>gpadc_reg_result</name>
 						<description>gpadc_reg_result.</description>
 						<addressOffset>0x930</addressOffset>
+						<resetValue>0x01ef0000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_data_out</name>
 								<lsb>0</lsb>
 								<msb>25</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -19952,11 +20010,14 @@
 						<name>gpadc_reg_raw_result</name>
 						<description>gpadc_reg_raw_result.</description>
 						<addressOffset>0x934</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_raw_data</name>
 								<lsb>0</lsb>
 								<msb>11</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -19964,6 +20025,8 @@
 						<name>gpadc_reg_define</name>
 						<description>gpadc_reg_define.</description>
 						<addressOffset>0x938</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_os_cal_data</name>
@@ -19976,6 +20039,8 @@
 						<name>hbncore_resv0</name>
 						<description>hbncore_resv0.</description>
 						<addressOffset>0x93C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>hbncore_resv0_data</name>
@@ -19988,6 +20053,8 @@
 						<name>hbncore_resv1</name>
 						<description>hbncore_resv1.</description>
 						<addressOffset>0x940</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>hbncore_resv1_data</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -10277,6 +10277,8 @@
 						<name>tzc_rom_ctrl</name>
 						<description>tzc_rom_ctrl.</description>
 						<addressOffset>0x40</addressOffset>
+						<resetValue>0x00000f0f</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tzc_sboot_done</name>
@@ -10369,6 +10371,8 @@
 						<name>tzc_rom0_r0</name>
 						<description>tzc_rom0_r0.</description>
 						<addressOffset>0x44</addressOffset>
+						<resetValue>0x0000ffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tzc_rom0_r0_start</name>
@@ -10386,6 +10390,8 @@
 						<name>tzc_rom0_r1</name>
 						<description>tzc_rom0_r1.</description>
 						<addressOffset>0x48</addressOffset>
+						<resetValue>0x0000ffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tzc_rom0_r1_start</name>
@@ -10403,6 +10409,8 @@
 						<name>tzc_rom1_r0</name>
 						<description>tzc_rom1_r0.</description>
 						<addressOffset>0x4C</addressOffset>
+						<resetValue>0x0000ffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tzc_rom1_r0_start</name>
@@ -10420,6 +10428,8 @@
 						<name>tzc_rom1_r1</name>
 						<description>tzc_rom1_r1.</description>
 						<addressOffset>0x50</addressOffset>
+						<resetValue>0x0000ffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>tzc_rom1_r1_start</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -15822,6 +15822,8 @@
 						<name>sf_ctrl_0</name>
 						<description>sf_ctrl_0.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x1ad2001c</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_id</name>
@@ -15867,6 +15869,7 @@
 								<name>sf_if_int</name>
 								<lsb>16</lsb>
 								<msb>16</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>sf_if_read_dly_en</name>
@@ -15904,6 +15907,8 @@
 						<name>sf_ctrl_1</name>
 						<description>sf_ctrl_1.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0xf3600000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_ahb2sram_en</name>
@@ -15934,6 +15939,7 @@
 								<name>sf_ahb2sif_stopped</name>
 								<lsb>26</lsb>
 								<msb>26</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>sf_if_reg_wp</name>
@@ -15964,6 +15970,7 @@
 								<name>sf_if_sr_int</name>
 								<lsb>16</lsb>
 								<msb>16</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>sf_if_sr_pat</name>
@@ -15981,6 +15988,8 @@
 						<name>sf_if_sahb_0</name>
 						<description>sf_if_sahb_0.</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_if_0_qpi_mode_en</name>
@@ -16046,6 +16055,7 @@
 								<name>sf_if_busy</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -16053,6 +16063,8 @@
 						<name>sf_if_sahb_1</name>
 						<description>sf_if_sahb_1.</description>
 						<addressOffset>0xC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_if_0_cmd_buf_0</name>
@@ -16065,6 +16077,8 @@
 						<name>sf_if_sahb_2</name>
 						<description>sf_if_sahb_2.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_if_0_cmd_buf_1</name>
@@ -16077,6 +16091,8 @@
 						<name>sf_if_iahb_0</name>
 						<description>sf_if_iahb_0.</description>
 						<addressOffset>0x14</addressOffset>
+						<resetValue>0x0d040000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_if_1_qpi_mode_en</name>
@@ -16134,6 +16150,8 @@
 						<name>sf_if_iahb_1</name>
 						<description>sf_if_iahb_1.</description>
 						<addressOffset>0x18</addressOffset>
+						<resetValue>0x03000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_if_1_cmd_buf_0</name>
@@ -16146,6 +16164,8 @@
 						<name>sf_if_iahb_2</name>
 						<description>sf_if_iahb_2.</description>
 						<addressOffset>0x1C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_if_1_cmd_buf_1</name>
@@ -16158,6 +16178,9 @@
 						<name>sf_if_status_0</name>
 						<description>sf_if_status_0.</description>
 						<addressOffset>0x20</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>sf_if_status_0</name>
@@ -16170,6 +16193,9 @@
 						<name>sf_if_status_1</name>
 						<description>sf_if_status_1.</description>
 						<addressOffset>0x24</addressOffset>
+						<resetValue>0x20000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>sf_if_status_1</name>
@@ -16182,16 +16208,20 @@
 						<name>sf_aes</name>
 						<description>sf_aes.</description>
 						<addressOffset>0x28</addressOffset>
+						<resetValue>0x00000040</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_status</name>
 								<lsb>5</lsb>
 								<msb>31</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>sf_aes_pref_busy</name>
 								<lsb>4</lsb>
 								<msb>4</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>sf_aes_pref_trig</name>
@@ -16214,6 +16244,9 @@
 						<name>sf_ahb2sif_status</name>
 						<description>sf_ahb2sif_status.</description>
 						<addressOffset>0x2C</addressOffset>
+						<resetValue>0x10000003</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>sf_ahb2sif_status</name>
@@ -16226,6 +16259,8 @@
 						<name>sf_if_io_dly_0</name>
 						<description>sf_if_io_dly_0.</description>
 						<addressOffset>0x30</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_dqs_do_dly_sel</name>
@@ -16258,6 +16293,8 @@
 						<name>sf_if_io_dly_1</name>
 						<description>sf_if_io_dly_1.</description>
 						<addressOffset>0x34</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_io_0_do_dly_sel</name>
@@ -16280,6 +16317,8 @@
 						<name>sf_if_io_dly_2</name>
 						<description>sf_if_io_dly_2.</description>
 						<addressOffset>0x38</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_io_1_do_dly_sel</name>
@@ -16302,6 +16341,8 @@
 						<name>sf_if_io_dly_3</name>
 						<description>sf_if_io_dly_3.</description>
 						<addressOffset>0x3C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_io_2_do_dly_sel</name>
@@ -16324,6 +16365,8 @@
 						<name>sf_if_io_dly_4</name>
 						<description>sf_if_io_dly_4.</description>
 						<addressOffset>0x40</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_io_3_do_dly_sel</name>
@@ -16358,6 +16401,8 @@
 						<name>sf2_if_io_dly_0</name>
 						<description>sf2_if_io_dly_0.</description>
 						<addressOffset>0x48</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf2_dqs_do_dly_sel</name>
@@ -16390,6 +16435,8 @@
 						<name>sf2_if_io_dly_1</name>
 						<description>sf2_if_io_dly_1.</description>
 						<addressOffset>0x4C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf2_io_0_do_dly_sel</name>
@@ -16412,6 +16459,8 @@
 						<name>sf2_if_io_dly_2</name>
 						<description>sf2_if_io_dly_2.</description>
 						<addressOffset>0x50</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf2_io_1_do_dly_sel</name>
@@ -16434,6 +16483,8 @@
 						<name>sf2_if_io_dly_3</name>
 						<description>sf2_if_io_dly_3.</description>
 						<addressOffset>0x54</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf2_io_2_do_dly_sel</name>
@@ -16456,6 +16507,8 @@
 						<name>sf2_if_io_dly_4</name>
 						<description>sf2_if_io_dly_4.</description>
 						<addressOffset>0x58</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf2_io_3_do_dly_sel</name>
@@ -16478,6 +16531,8 @@
 						<name>sf3_if_io_dly_0</name>
 						<description>sf3_if_io_dly_0.</description>
 						<addressOffset>0x5C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf3_dqs_do_dly_sel</name>
@@ -16510,6 +16565,8 @@
 						<name>sf3_if_io_dly_1</name>
 						<description>sf3_if_io_dly_1.</description>
 						<addressOffset>0x60</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf3_io_0_do_dly_sel</name>
@@ -16532,6 +16589,8 @@
 						<name>sf3_if_io_dly_2</name>
 						<description>sf3_if_io_dly_2.</description>
 						<addressOffset>0x64</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf3_io_1_do_dly_sel</name>
@@ -16554,6 +16613,8 @@
 						<name>sf3_if_io_dly_3</name>
 						<description>sf3_if_io_dly_3.</description>
 						<addressOffset>0x68</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf3_io_2_do_dly_sel</name>
@@ -16576,6 +16637,8 @@
 						<name>sf3_if_io_dly_4</name>
 						<description>sf3_if_io_dly_4.</description>
 						<addressOffset>0x6C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf3_io_3_do_dly_sel</name>
@@ -16598,6 +16661,8 @@
 						<name>sf_ctrl_2</name>
 						<description>sf_ctrl_2.</description>
 						<addressOffset>0x70</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_if_dqs_en</name>
@@ -16625,6 +16690,8 @@
 						<name>sf_ctrl_3</name>
 						<description>sf_ctrl_3.</description>
 						<addressOffset>0x74</addressOffset>
+						<resetValue>0x20000046</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_if_1_ack_lat</name>
@@ -16667,6 +16734,8 @@
 						<name>sf_if_iahb_3</name>
 						<description>sf_if_iahb_3.</description>
 						<addressOffset>0x78</addressOffset>
+						<resetValue>0x8d840000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_if_2_qpi_mode_en</name>
@@ -16724,6 +16793,8 @@
 						<name>sf_if_iahb_4</name>
 						<description>sf_if_iahb_4.</description>
 						<addressOffset>0x7C</addressOffset>
+						<resetValue>0x38000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_if_2_cmd_buf_0</name>
@@ -16736,6 +16807,8 @@
 						<name>sf_if_iahb_5</name>
 						<description>sf_if_iahb_5.</description>
 						<addressOffset>0x80</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_if_2_cmd_buf_1</name>
@@ -16748,6 +16821,8 @@
 						<name>sf_if_iahb_6</name>
 						<description>sf_if_iahb_6.</description>
 						<addressOffset>0x84</addressOffset>
+						<resetValue>0x80000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_if_3_qpi_mode_en</name>
@@ -16770,6 +16845,8 @@
 						<name>sf_if_iahb_7</name>
 						<description>sf_if_iahb_7.</description>
 						<addressOffset>0x88</addressOffset>
+						<resetValue>0xc0000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_if_3_cmd_buf_0</name>
@@ -16782,6 +16859,9 @@
 						<name>sf_ctrl_prot_en_rd</name>
 						<description>sf_ctrl_prot_en_rd.</description>
 						<addressOffset>0x100</addressOffset>
+						<resetValue>0x00000007</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>sf_dbg_dis</name>
@@ -16814,6 +16894,8 @@
 						<name>sf_ctrl_prot_en</name>
 						<description>sf_ctrl_prot_en.</description>
 						<addressOffset>0x104</addressOffset>
+						<resetValue>0x00000007</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_ctrl_id1_en</name>
@@ -16836,6 +16918,8 @@
 						<name>sf_aes_key_r0_0</name>
 						<description>sf_aes_key_r0_0.</description>
 						<addressOffset>0x200</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_0</name>
@@ -16848,6 +16932,8 @@
 						<name>sf_aes_key_r0_1</name>
 						<description>sf_aes_key_r0_1.</description>
 						<addressOffset>0x204</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_1</name>
@@ -16860,6 +16946,8 @@
 						<name>sf_aes_key_r0_2</name>
 						<description>sf_aes_key_r0_2.</description>
 						<addressOffset>0x208</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_2</name>
@@ -16872,6 +16960,8 @@
 						<name>sf_aes_key_r0_3</name>
 						<description>sf_aes_key_r0_3.</description>
 						<addressOffset>0x20C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_3</name>
@@ -16884,6 +16974,8 @@
 						<name>sf_aes_key_r0_4</name>
 						<description>sf_aes_key_r0_4.</description>
 						<addressOffset>0x210</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_4</name>
@@ -16896,6 +16988,8 @@
 						<name>sf_aes_key_r0_5</name>
 						<description>sf_aes_key_r0_5.</description>
 						<addressOffset>0x214</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_5</name>
@@ -16908,6 +17002,8 @@
 						<name>sf_aes_key_r0_6</name>
 						<description>sf_aes_key_r0_6.</description>
 						<addressOffset>0x218</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_6</name>
@@ -16920,6 +17016,8 @@
 						<name>sf_aes_key_r0_7</name>
 						<description>sf_aes_key_r0_7.</description>
 						<addressOffset>0x21C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r0_7</name>
@@ -16932,6 +17030,8 @@
 						<name>sf_aes_iv_r0_w0</name>
 						<description>sf_aes_iv_r0_w0.</description>
 						<addressOffset>0x220</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r0_w0</name>
@@ -16944,6 +17044,8 @@
 						<name>sf_aes_iv_r0_w1</name>
 						<description>sf_aes_iv_r0_w1.</description>
 						<addressOffset>0x224</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r0_w1</name>
@@ -16956,6 +17058,8 @@
 						<name>sf_aes_iv_r0_w2</name>
 						<description>sf_aes_iv_r0_w2.</description>
 						<addressOffset>0x228</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r0_w2</name>
@@ -16968,6 +17072,8 @@
 						<name>sf_aes_iv_r0_w3</name>
 						<description>sf_aes_iv_r0_w3.</description>
 						<addressOffset>0x22C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r0_w3</name>
@@ -16980,6 +17086,8 @@
 						<name>sf_aes_cfg_r0</name>
 						<description>sf_aes_cfg_r0.</description>
 						<addressOffset>0x230</addressOffset>
+						<resetValue>0x00003fff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_region_r0_lock</name>
@@ -17012,6 +17120,8 @@
 						<name>sf_aes_key_r1_0</name>
 						<description>sf_aes_key_r1_0.</description>
 						<addressOffset>0x300</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_0</name>
@@ -17024,6 +17134,8 @@
 						<name>sf_aes_key_r1_1</name>
 						<description>sf_aes_key_r1_1.</description>
 						<addressOffset>0x304</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_1</name>
@@ -17036,6 +17148,8 @@
 						<name>sf_aes_key_r1_2</name>
 						<description>sf_aes_key_r1_2.</description>
 						<addressOffset>0x308</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_2</name>
@@ -17048,6 +17162,8 @@
 						<name>sf_aes_key_r1_3</name>
 						<description>sf_aes_key_r1_3.</description>
 						<addressOffset>0x30C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_3</name>
@@ -17060,6 +17176,8 @@
 						<name>sf_aes_key_r1_4</name>
 						<description>sf_aes_key_r1_4.</description>
 						<addressOffset>0x310</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_4</name>
@@ -17072,6 +17190,8 @@
 						<name>sf_aes_key_r1_5</name>
 						<description>sf_aes_key_r1_5.</description>
 						<addressOffset>0x314</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_5</name>
@@ -17084,6 +17204,8 @@
 						<name>sf_aes_key_r1_6</name>
 						<description>sf_aes_key_r1_6.</description>
 						<addressOffset>0x318</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_6</name>
@@ -17096,6 +17218,8 @@
 						<name>sf_aes_key_r1_7</name>
 						<description>sf_aes_key_r1_7.</description>
 						<addressOffset>0x31C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r1_7</name>
@@ -17108,6 +17232,8 @@
 						<name>sf_aes_iv_r1_w0</name>
 						<description>sf_aes_iv_r1_w0.</description>
 						<addressOffset>0x320</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r1_w0</name>
@@ -17120,6 +17246,8 @@
 						<name>sf_aes_iv_r1_w1</name>
 						<description>sf_aes_iv_r1_w1.</description>
 						<addressOffset>0x324</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r1_w1</name>
@@ -17132,6 +17260,8 @@
 						<name>sf_aes_iv_r1_w2</name>
 						<description>sf_aes_iv_r1_w2.</description>
 						<addressOffset>0x328</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r1_w2</name>
@@ -17144,6 +17274,8 @@
 						<name>sf_aes_iv_r1_w3</name>
 						<description>sf_aes_iv_r1_w3.</description>
 						<addressOffset>0x32C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r1_w3</name>
@@ -17156,6 +17288,8 @@
 						<name>sf_aes_r1</name>
 						<description>sf_aes_r1.</description>
 						<addressOffset>0x330</addressOffset>
+						<resetValue>0x00003fff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_r1_lock</name>
@@ -17188,6 +17322,8 @@
 						<name>sf_aes_key_r2_0</name>
 						<description>sf_aes_key_r2_0.</description>
 						<addressOffset>0x400</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_0</name>
@@ -17200,6 +17336,10 @@
 						<name>sf_aes_key_r2_1</name>
 						<description>sf_aes_key_r2_1.</description>
 						<addressOffset>0x404</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_1</name>
@@ -17224,6 +17364,8 @@
 						<name>sf_aes_key_r2_3</name>
 						<description>sf_aes_key_r2_3.</description>
 						<addressOffset>0x40C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_3</name>
@@ -17236,6 +17378,8 @@
 						<name>sf_aes_key_r2_4</name>
 						<description>sf_aes_key_r2_4.</description>
 						<addressOffset>0x410</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_4</name>
@@ -17248,6 +17392,8 @@
 						<name>sf_aes_key_r2_5</name>
 						<description>sf_aes_key_r2_5.</description>
 						<addressOffset>0x414</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_5</name>
@@ -17260,6 +17406,8 @@
 						<name>sf_aes_key_r2_6</name>
 						<description>sf_aes_key_r2_6.</description>
 						<addressOffset>0x418</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_6</name>
@@ -17272,6 +17420,8 @@
 						<name>sf_aes_key_r2_7</name>
 						<description>sf_aes_key_r2_7.</description>
 						<addressOffset>0x41C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_7</name>
@@ -17284,6 +17434,8 @@
 						<name>sf_aes_iv_r2_w0</name>
 						<description>sf_aes_iv_r2_w0.</description>
 						<addressOffset>0x420</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r2_w0</name>
@@ -17296,6 +17448,8 @@
 						<name>sf_aes_iv_r2_w1</name>
 						<description>sf_aes_iv_r2_w1.</description>
 						<addressOffset>0x424</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r2_w1</name>
@@ -17308,6 +17462,8 @@
 						<name>sf_aes_iv_r2_w2</name>
 						<description>sf_aes_iv_r2_w2.</description>
 						<addressOffset>0x428</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r2_w2</name>
@@ -17320,6 +17476,8 @@
 						<name>sf_aes_iv_r2_w3</name>
 						<description>sf_aes_iv_r2_w3.</description>
 						<addressOffset>0x42C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_iv_r2_w3</name>
@@ -17332,6 +17490,8 @@
 						<name>sf_aes_r2</name>
 						<description>sf_aes_r2.</description>
 						<addressOffset>0x430</addressOffset>
+						<resetValue>0x00003fff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_r2_lock</name>
@@ -17364,6 +17524,8 @@
 						<name>sf_id0_offset</name>
 						<description>sf_id0_offset.</description>
 						<addressOffset>0x434</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_id0_offset</name>
@@ -17376,6 +17538,8 @@
 						<name>sf_id1_offset</name>
 						<description>sf_id1_offset.</description>
 						<addressOffset>0x438</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_id1_offset</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -8424,6 +8424,9 @@
 						<name>sd_chip_id_low</name>
 						<description>sd_chip_id_low.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>sd_chip_id_low</name>
@@ -8436,6 +8439,9 @@
 						<name>sd_chip_id_high</name>
 						<description>sd_chip_id_high.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>sd_chip_id_high</name>
@@ -8448,6 +8454,9 @@
 						<name>sd_wifi_mac_low</name>
 						<description>sd_wifi_mac_low.</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>sd_wifi_mac_low</name>
@@ -8460,6 +8469,9 @@
 						<name>sd_wifi_mac_high</name>
 						<description>sd_wifi_mac_high.</description>
 						<addressOffset>0xC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>sd_wifi_mac_high</name>
@@ -8472,6 +8484,8 @@
 						<name>sd_dbg_pwd_low</name>
 						<description>sd_dbg_pwd_low.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sd_dbg_pwd_low</name>
@@ -8484,6 +8498,8 @@
 						<name>sd_dbg_pwd_high</name>
 						<description>sd_dbg_pwd_high.</description>
 						<addressOffset>0x14</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sd_dbg_pwd_high</name>
@@ -8496,21 +8512,26 @@
 						<name>sd_status</name>
 						<description>sd_status.</description>
 						<addressOffset>0x18</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sd_dbg_ena</name>
 								<lsb>28</lsb>
 								<msb>31</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>sd_dbg_mode</name>
 								<lsb>24</lsb>
 								<msb>27</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>sd_dbg_pwd_cnt</name>
 								<lsb>4</lsb>
 								<msb>23</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>sd_dbg_cci_clk_sel</name>
@@ -8531,6 +8552,7 @@
 								<name>sd_dbg_pwd_busy</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -18694,16 +18694,20 @@
 						<name>HBN_CTL</name>
 						<description>HBN_CTL.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x00d50000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>hbn_state</name>
 								<lsb>28</lsb>
 								<msb>31</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>sram_slp</name>
 								<lsb>27</lsb>
 								<msb>27</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>sram_slp_option</name>
@@ -18764,11 +18768,13 @@
 								<name>trap_mode</name>
 								<lsb>8</lsb>
 								<msb>8</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>hbn_mode</name>
 								<lsb>7</lsb>
 								<msb>7</msb>
+								<access>write-only</access>
 							</field>
 							<field>
 								<name>rtc_ctl</name>
@@ -18781,6 +18787,8 @@
 						<name>HBN_TIME_L</name>
 						<description>HBN_TIME_L.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>hbn_time_l</name>
@@ -18793,6 +18801,8 @@
 						<name>HBN_TIME_H</name>
 						<description>HBN_TIME_H.</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>hbn_time_h</name>
@@ -18805,6 +18815,9 @@
 						<name>RTC_TIME_L</name>
 						<description>RTC_TIME_L.</description>
 						<addressOffset>0xC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>rtc_time_latch_l</name>
@@ -18817,16 +18830,20 @@
 						<name>RTC_TIME_H</name>
 						<description>RTC_TIME_H.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rtc_time_latch</name>
 								<lsb>31</lsb>
 								<msb>31</msb>
+								<access>write-only</access>
 							</field>
 							<field>
 								<name>rtc_time_latch_h</name>
 								<lsb>0</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -18834,6 +18851,8 @@
 						<name>HBN_IRQ_MODE</name>
 						<description>HBN_IRQ_MODE.</description>
 						<addressOffset>0x14</addressOffset>
+						<resetValue>0x03010105</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>pin_wakeup_en</name>
@@ -18886,6 +18905,9 @@
 						<name>HBN_IRQ_STAT</name>
 						<description>HBN_IRQ_STAT.</description>
 						<addressOffset>0x18</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>irq_stat</name>
@@ -18898,6 +18920,9 @@
 						<name>HBN_IRQ_CLR</name>
 						<description>HBN_IRQ_CLR.</description>
 						<addressOffset>0x1C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>write-only</access>
 						<fields>
 							<field>
 								<name>irq_clr</name>
@@ -18910,6 +18935,8 @@
 						<name>HBN_PIR_CFG</name>
 						<description>HBN_PIR_CFG.</description>
 						<addressOffset>0x20</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>gpadc_nosync</name>
@@ -18947,6 +18974,8 @@
 						<name>HBN_PIR_VTH</name>
 						<description>HBN_PIR_VTH.</description>
 						<addressOffset>0x24</addressOffset>
+						<resetValue>0x000003ff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>pir_vth</name>
@@ -18959,6 +18988,8 @@
 						<name>HBN_PIR_INTERVAL</name>
 						<description>HBN_PIR_INTERVAL.</description>
 						<addressOffset>0x28</addressOffset>
+						<resetValue>0x00000a3d</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>pir_interval</name>
@@ -18971,11 +19002,14 @@
 						<name>HBN_BOR_CFG</name>
 						<description>HBN_BOR_CFG.</description>
 						<addressOffset>0x2C</addressOffset>
+						<resetValue>0x00000002</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>r_bor_out</name>
 								<lsb>3</lsb>
 								<msb>3</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>pu_bor</name>
@@ -18998,6 +19032,8 @@
 						<name>HBN_GLB</name>
 						<description>HBN_GLB.</description>
 						<addressOffset>0x30</addressOffset>
+						<resetValue>0xaa0a0020</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sw_ldo11_aon_vout_sel</name>
@@ -19040,6 +19076,8 @@
 						<name>HBN_SRAM</name>
 						<description>HBN_SRAM.</description>
 						<addressOffset>0x34</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>retram_slp</name>
@@ -19057,6 +19095,8 @@
 						<name>HBN_RSV0</name>
 						<description>HBN_RSV0.</description>
 						<addressOffset>0x100</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>HBN_RSV0</name>
@@ -19069,6 +19109,8 @@
 						<name>HBN_RSV1</name>
 						<description>HBN_RSV1.</description>
 						<addressOffset>0x104</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>HBN_RSV1</name>
@@ -19081,6 +19123,8 @@
 						<name>HBN_RSV2</name>
 						<description>HBN_RSV2.</description>
 						<addressOffset>0x108</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>HBN_RSV2</name>
@@ -19093,6 +19137,8 @@
 						<name>HBN_RSV3</name>
 						<description>HBN_RSV3.</description>
 						<addressOffset>0x10C</addressOffset>
+						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>HBN_RSV3</name>
@@ -19105,6 +19151,8 @@
 						<name>rc32k_ctrl0</name>
 						<description>rc32k_ctrl0.</description>
 						<addressOffset>0x200</addressOffset>
+						<resetValue>0x5008801b</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rc32k_code_fr_ext</name>
@@ -19135,11 +19183,13 @@
 								<name>rc32k_dig_code_fr_cal</name>
 								<lsb>6</lsb>
 								<msb>15</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rc32k_cal_precharge</name>
 								<lsb>5</lsb>
 								<msb>5</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rc32k_cal_div</name>
@@ -19150,16 +19200,19 @@
 								<name>rc32k_cal_inprogress</name>
 								<lsb>2</lsb>
 								<msb>2</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rc32k_rdy</name>
 								<lsb>1</lsb>
 								<msb>1</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rc32k_cal_done</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -19167,6 +19220,8 @@
 						<name>xtal32k</name>
 						<description>xtal32k.</description>
 						<addressOffset>0x204</addressOffset>
+						<resetValue>0x000f0228</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>pu_xtal32k</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -15136,12 +15136,27 @@
 						<name>cks_config</name>
 						<description>cks_config.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_cks_byte_swap</name>
-								<description>Endianness (0: little endian, 1: big endian)</description>
+								<description>Endianness.</description>
 								<lsb>1</lsb>
 								<msb>1</msb>
+								<enumeratedValues>
+									<name>CKSByteSwap</name>
+									<enumeratedValue>
+										<name>little_endian</name>
+										<description>Little endian.</description>
+										<value>0</value>
+									</enumeratedValue>
+									<enumeratedValue>
+										<name>big_endian</name>
+										<description>Big endian.</description>
+										<value>1</value>
+									</enumeratedValue>
+								</enumeratedValues>
 							</field>
 							<field>
 								<name>cr_cks_clr</name>
@@ -15154,11 +15169,14 @@
 						<name>data_in</name>
 						<description>Checksum data in</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>data_in</name>
 								<lsb>0</lsb>
 								<msb>7</msb>
+								<access>write-only</access>
 							</field>
 						</fields>
 					</register>
@@ -15166,11 +15184,14 @@
 						<name>cks_out</name>
 						<description>Checksum value out</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0x0000ffff</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cks_out</name>
 								<lsb>0</lsb>
 								<msb>15</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -45,11 +45,13 @@
 								<name>chip_rdy</name>
 								<lsb>27</lsb>
 								<msb>27</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>fclk_sw_state</name>
 								<lsb>24</lsb>
 								<msb>26</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>reg_bclk_div</name>
@@ -67,6 +69,7 @@
 								<name>hbn_root_clk_sel</name>
 								<lsb>6</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>reg_pll_sel</name>
@@ -1130,12 +1133,12 @@
 						<addressOffset>0xE0</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetValue>0xffffffff</resetValue>
-						<access>read-only</access>
 						<fields>
 							<field>
 								<name>debug_i</name>
 								<lsb>1</lsb>
 								<msb>31</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>debug_oe</name>
@@ -9658,9 +9661,10 @@
 						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
-								<name>se_trng_0_rosc_en</name>
+								<name>se_trng_0_rosc_dis</name>
 								<lsb>31</lsb>
 								<msb>31</msb>
+								<description>Used to be called 'se_trng_0_rosc_en', but the SDK calls it 'se_trng_0_rosc_dis'.</description>
 							</field>
 							<field>
 								<name>se_trng_0_ht_od_en</name>
@@ -12278,7 +12282,7 @@
 						<name>ef_crc_ctrl_4</name>
 						<description>ef_crc_ctrl_4.</description>
 						<addressOffset>0xA10</addressOffset>
-						<resetValue>0xffffffff</resetValue>
+						<resetValue>0xc2a8fa9d</resetValue>
 						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
@@ -17535,8 +17539,6 @@
 						<addressOffset>0x404</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetValue>0xffffffff</resetValue>
-						<resetValue>0x00000000</resetValue>
-						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_1</name>
@@ -17549,6 +17551,8 @@
 						<name>sf_aes_key_r2_2</name>
 						<description>sf_aes_key_r2_2.</description>
 						<addressOffset>0x408</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>sf_aes_key_r2_2</name>
@@ -18015,7 +18019,7 @@
 						<name>DMA_C0Control</name>
 						<description>DMA_C0Control.</description>
 						<addressOffset>0x10C</addressOffset>
-						<resetValue>0x00000000</resetValue>
+						<resetValue>0x0c489000</resetValue>
 						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -12851,6 +12851,7 @@
 								<name>tx_fifo_underflow</name>
 								<lsb>5</lsb>
 								<msb>5</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>tx_fifo_overflow</name>
@@ -13228,6 +13229,7 @@
 								<name>rx_fifo_overflow</name>
 								<lsb>6</lsb>
 								<msb>6</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>tx_fifo_underflow</name>
@@ -13331,6 +13333,8 @@
 						<name>i2c_config</name>
 						<description>i2c_config.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x0000000a</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_i2c_deg_cnt</name>
@@ -13383,6 +13387,8 @@
 						<name>i2c_int_sts</name>
 						<description>i2c_int_sts.</description>
 						<addressOffset>0x4</addressOffset>
+						<resetValue>0x3f003f00</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_i2c_fer_en</name>
@@ -13478,31 +13484,37 @@
 								<name>i2c_fer_int</name>
 								<lsb>5</lsb>
 								<msb>5</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>i2c_arb_int</name>
 								<lsb>4</lsb>
 								<msb>4</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>i2c_nak_int</name>
 								<lsb>3</lsb>
 								<msb>3</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>i2c_rxf_int</name>
 								<lsb>2</lsb>
 								<msb>2</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>i2c_txf_int</name>
 								<lsb>1</lsb>
 								<msb>1</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>i2c_end_int</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -13510,6 +13522,8 @@
 						<name>i2c_sub_addr</name>
 						<description>i2c_sub_addr.</description>
 						<addressOffset>0x8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_i2c_sub_addr_b3</name>
@@ -13537,6 +13551,8 @@
 						<name>i2c_bus_busy</name>
 						<description>i2c_bus_busy.</description>
 						<addressOffset>0xC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_i2c_bus_busy_clr</name>
@@ -13547,6 +13563,7 @@
 								<name>sts_i2c_bus_busy</name>
 								<lsb>0</lsb>
 								<msb>0</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -13554,6 +13571,8 @@
 						<name>i2c_prd_start</name>
 						<description>i2c_prd_start.</description>
 						<addressOffset>0x10</addressOffset>
+						<resetValue>0x0f0f0f0f</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_i2c_prd_s_ph_3</name>
@@ -13581,6 +13600,8 @@
 						<name>i2c_prd_stop</name>
 						<description>i2c_prd_stop.</description>
 						<addressOffset>0x14</addressOffset>
+						<resetValue>0x0f0f0f0f</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_i2c_prd_p_ph_3</name>
@@ -13608,6 +13629,8 @@
 						<name>i2c_prd_data</name>
 						<description>i2c_prd_data.</description>
 						<addressOffset>0x18</addressOffset>
+						<resetValue>0x0f0f0f0f</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>cr_i2c_prd_d_ph_3</name>
@@ -13635,11 +13658,14 @@
 						<name>i2c_fifo_config_0</name>
 						<description>i2c_fifo_config_0.</description>
 						<addressOffset>0x80</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rx_fifo_underflow</name>
 								<lsb>7</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rx_fifo_overflow</name>
@@ -13655,6 +13681,7 @@
 								<name>tx_fifo_overflow</name>
 								<lsb>4</lsb>
 								<msb>4</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rx_fifo_clr</name>
@@ -13682,6 +13709,8 @@
 						<name>i2c_fifo_config_1</name>
 						<description>i2c_fifo_config_1.</description>
 						<addressOffset>0x84</addressOffset>
+						<resetValue>0x00000002</resetValue>
+						<resetValue>0xffffffff</resetValue>
 						<fields>
 							<field>
 								<name>rx_fifo_th</name>
@@ -13702,6 +13731,7 @@
 								<name>tx_fifo_cnt</name>
 								<lsb>0</lsb>
 								<msb>1</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -13709,6 +13739,9 @@
 						<name>i2c_fifo_wdata</name>
 						<description>i2c_fifo_wdata.</description>
 						<addressOffset>0x88</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>write-only</access>
 						<fields>
 							<field>
 								<name>i2c_fifo_wdata</name>
@@ -13721,6 +13754,9 @@
 						<name>i2c_fifo_rdata</name>
 						<description>i2c_fifo_rdata.</description>
 						<addressOffset>0x8C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetValue>0xffffffff</resetValue>
+						<access>read-only</access>
 						<fields>
 							<field>
 								<name>i2c_fifo_rdata</name>
@@ -15356,6 +15392,7 @@
 								<name>rx_fifo_cnt</name>
 								<lsb>4</lsb>
 								<msb>10</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>rx_fifo_underflow</name>

--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -13465,16 +13465,20 @@
 						<name>pwm_int_config</name>
 						<description>pwm_int_config.</description>
 						<addressOffset>0x0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_int_clear</name>
 								<lsb>8</lsb>
 								<msb>13</msb>
+								<access>write-only</access>
 							</field>
 							<field>
 								<name>pwm_interrupt_sts</name>
 								<lsb>0</lsb>
 								<msb>5</msb>
+								<access>read-only</access>
 							</field>
 						</fields>
 					</register>
@@ -13482,6 +13486,8 @@
 						<name>pwm0_clkdiv</name>
 						<description>pwm0_clkdiv.</description>
 						<addressOffset>0x20</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_clk_div</name>
@@ -13494,6 +13500,8 @@
 						<name>pwm0_thre1</name>
 						<description>pwm0_thre1.</description>
 						<addressOffset>0x24</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_thre1</name>
@@ -13506,6 +13514,8 @@
 						<name>pwm0_thre2</name>
 						<description>pwm0_thre2.</description>
 						<addressOffset>0x28</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_thre2</name>
@@ -13518,6 +13528,8 @@
 						<name>pwm0_period</name>
 						<description>pwm0_period.</description>
 						<addressOffset>0x2C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_period</name>
@@ -13530,11 +13542,14 @@
 						<name>pwm0_config</name>
 						<description>pwm0_config.</description>
 						<addressOffset>0x30</addressOffset>
+						<resetValue>0x00000008</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_sts_top</name>
 								<lsb>7</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>pwm_stop_en</name>
@@ -13572,6 +13587,8 @@
 						<name>pwm0_interrupt</name>
 						<description>pwm0_interrupt.</description>
 						<addressOffset>0x34</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_int_enable</name>
@@ -13589,6 +13606,8 @@
 						<name>pwm1_clkdiv</name>
 						<description>pwm1_clkdiv.</description>
 						<addressOffset>0x40</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_clk_div</name>
@@ -13601,6 +13620,8 @@
 						<name>pwm1_thre1</name>
 						<description>pwm1_thre1.</description>
 						<addressOffset>0x44</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_thre1</name>
@@ -13613,6 +13634,8 @@
 						<name>pwm1_thre2</name>
 						<description>pwm1_thre2.</description>
 						<addressOffset>0x48</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_thre2</name>
@@ -13625,6 +13648,8 @@
 						<name>pwm1_period</name>
 						<description>pwm1_period.</description>
 						<addressOffset>0x4C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_period</name>
@@ -13637,11 +13662,14 @@
 						<name>pwm1_config</name>
 						<description>pwm1_config.</description>
 						<addressOffset>0x50</addressOffset>
+						<resetValue>0x00000008</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_sts_top</name>
 								<lsb>7</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>pwm_stop_en</name>
@@ -13679,6 +13707,8 @@
 						<name>pwm1_interrupt</name>
 						<description>pwm1_interrupt.</description>
 						<addressOffset>0x54</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_int_enable</name>
@@ -13696,6 +13726,8 @@
 						<name>pwm2_clkdiv</name>
 						<description>pwm2_clkdiv.</description>
 						<addressOffset>0x60</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_clk_div</name>
@@ -13708,6 +13740,8 @@
 						<name>pwm2_thre1</name>
 						<description>pwm2_thre1.</description>
 						<addressOffset>0x64</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_thre1</name>
@@ -13720,6 +13754,8 @@
 						<name>pwm2_thre2</name>
 						<description>pwm2_thre2.</description>
 						<addressOffset>0x68</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_thre2</name>
@@ -13732,6 +13768,8 @@
 						<name>pwm2_period</name>
 						<description>pwm2_period.</description>
 						<addressOffset>0x6C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_period</name>
@@ -13744,11 +13782,14 @@
 						<name>pwm2_config</name>
 						<description>pwm2_config.</description>
 						<addressOffset>0x70</addressOffset>
+						<resetValue>0x00000008</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_sts_top</name>
 								<lsb>7</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>pwm_stop_en</name>
@@ -13786,6 +13827,8 @@
 						<name>pwm2_interrupt</name>
 						<description>pwm2_interrupt.</description>
 						<addressOffset>0x74</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_int_enable</name>
@@ -13803,6 +13846,8 @@
 						<name>pwm3_clkdiv</name>
 						<description>pwm3_clkdiv.</description>
 						<addressOffset>0x80</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_clk_div</name>
@@ -13815,6 +13860,8 @@
 						<name>pwm3_thre1</name>
 						<description>pwm3_thre1.</description>
 						<addressOffset>0x84</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_thre1</name>
@@ -13827,6 +13874,8 @@
 						<name>pwm3_thre2</name>
 						<description>pwm3_thre2.</description>
 						<addressOffset>0x88</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_thre2</name>
@@ -13839,6 +13888,8 @@
 						<name>pwm3_period</name>
 						<description>pwm3_period.</description>
 						<addressOffset>0x8C</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_period</name>
@@ -13851,11 +13902,14 @@
 						<name>pwm3_config</name>
 						<description>pwm3_config.</description>
 						<addressOffset>0x90</addressOffset>
+						<resetValue>0x00000008</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_sts_top</name>
 								<lsb>7</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>pwm_stop_en</name>
@@ -13893,6 +13947,8 @@
 						<name>pwm3_interrupt</name>
 						<description>pwm3_interrupt.</description>
 						<addressOffset>0x94</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_int_enable</name>
@@ -13910,6 +13966,8 @@
 						<name>pwm4_clkdiv</name>
 						<description>pwm4_clkdiv.</description>
 						<addressOffset>0xA0</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_clk_div</name>
@@ -13922,6 +13980,8 @@
 						<name>pwm4_thre1</name>
 						<description>pwm4_thre1.</description>
 						<addressOffset>0xA4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_thre1</name>
@@ -13934,6 +13994,8 @@
 						<name>pwm4_thre2</name>
 						<description>pwm4_thre2.</description>
 						<addressOffset>0xA8</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_thre2</name>
@@ -13946,6 +14008,8 @@
 						<name>pwm4_period</name>
 						<description>pwm4_period.</description>
 						<addressOffset>0xAC</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_period</name>
@@ -13958,11 +14022,14 @@
 						<name>pwm4_config</name>
 						<description>pwm4_config.</description>
 						<addressOffset>0xB0</addressOffset>
+						<resetValue>0x00000008</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_sts_top</name>
 								<lsb>7</lsb>
 								<msb>7</msb>
+								<access>read-only</access>
 							</field>
 							<field>
 								<name>pwm_stop_en</name>
@@ -14000,6 +14067,8 @@
 						<name>pwm4_interrupt</name>
 						<description>pwm4_interrupt.</description>
 						<addressOffset>0xB4</addressOffset>
+						<resetValue>0x00000000</resetValue>
+						<resetMask>0xffffffff</resetMask>
 						<fields>
 							<field>
 								<name>pwm_int_enable</name>


### PR DESCRIPTION
This PR adds reset values and access modifiers directly from the SDK.

The struct fields (specific structs in each commit) parsed looked like
```
Unused		Name                       Width   LSB/MSB      Access       Reset value
V           V                          V         V           V           V
uint32_t field_name                 :  1; /* [   16],        r/w,        0x0 */
```

There are some fields with access values as `w1c` and `w1p`, although I do not know how to represent this in the SVD so they have not been included. In the future those modifiers should also be added.
