### PR TITLE
svd: Put the XML declaration at the very top

### DIFF
--- a/bl602.svd
+++ b/bl602.svd
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   Copyright (c) 2020 Sipeed Co.,Ltd.
   bl602-pac is licensed under Mulan PSL v2.
@@ -17,7 +18,6 @@
   If you want to debug a program using the PAC crate, debug on target ELF file 
   the PAC, HAL and your application are compiled into.
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd" >
   <vendor>Bouffalo Lab</vendor> <!-- The trademark here mentioned belongs to its owners -->
   <name>BL602</name>


### PR DESCRIPTION
According to the XML [specification][1], the XML declaration (XMLDecl) is allowed *only* as the very first production in the prolog, which in turn can appear only as the very first production in the document. This means it must come before all comments or the XML file is invalid. Java and Python XML parsers [fail][2] on documents like this one which violate that part of the spec.

Move the declaration up so our SVD is valid XML.

[1]: https://www.w3.org/TR/xml/#NT-prolog
[2]: https://stackoverflow.com/a/19898942/6568778