### PR TITLE
Remove disallowed <fields/> tags

### DIFF
--- a/soc602_reg.svd
+++ b/soc602_reg.svd
@@ -421,7 +421,6 @@
 						<addressOffset>0x1C</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>cgen_cfg0</name>
@@ -481,7 +480,6 @@
 						<addressOffset>0x2C</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>MBIST_CTL</name>
@@ -9978,7 +9976,6 @@
 						<name>saradc_resv</name>
 						<description>SARADC Control Registers</description>
 						<addressOffset>0x24</addressOffset>
-						<fields/>
 					</register>
 					<register>
 						<name>rf_base_ctrl1</name>
@@ -10026,7 +10023,6 @@
 						<name>rf_base_ctrl2</name>
 						<description>ZRF Control register 0</description>
 						<addressOffset>0x2C</addressOffset>
-						<fields/>
 					</register>
 					<register>
 						<name>pucr1</name>
@@ -10276,13 +10272,11 @@
 						<name>pucr2</name>
 						<description>pucr2.</description>
 						<addressOffset>0x38</addressOffset>
-						<fields/>
 					</register>
 					<register>
 						<name>pucr2_hw</name>
 						<description>pucr2_hw.</description>
 						<addressOffset>0x3C</addressOffset>
-						<fields/>
 					</register>
 					<register>
 						<name>ppu_ctrl_hw</name>
@@ -10672,7 +10666,6 @@
 						<name>pmip_mv2aon</name>
 						<description>pmip_mv2aon.</description>
 						<addressOffset>0x5C</addressOffset>
-						<fields/>
 					</register>
 					<register>
 						<name>cip</name>
@@ -16207,7 +16200,6 @@
 						<addressOffset>0x340</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>se_pka_0_rw_burst</name>
@@ -16215,7 +16207,6 @@
 						<addressOffset>0x360</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>se_pka_0_ctrl_prot</name>
@@ -17853,7 +17844,6 @@
 						<addressOffset>0x40</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_10_w1</name>
@@ -17861,7 +17851,6 @@
 						<addressOffset>0x44</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_10_w2</name>
@@ -17869,7 +17858,6 @@
 						<addressOffset>0x48</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_10_w3</name>
@@ -17877,7 +17865,6 @@
 						<addressOffset>0x4C</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_11_w0</name>
@@ -17885,7 +17872,6 @@
 						<addressOffset>0x50</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_11_w1</name>
@@ -17893,7 +17879,6 @@
 						<addressOffset>0x54</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_11_w2</name>
@@ -17901,7 +17886,6 @@
 						<addressOffset>0x58</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>reg_key_slot_11_w3</name>
@@ -17909,7 +17893,6 @@
 						<addressOffset>0x5C</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>reg_data_1_lock</name>
@@ -18903,7 +18886,6 @@
 						<addressOffset>0x10</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>l1c_bmx_err_addr_en</name>
@@ -18972,7 +18954,6 @@
 						<addressOffset>0x20C</addressOffset>
 						<resetValue>0x00000000</resetValue>
 						<resetMask>0xffffffff</resetMask>
-						<fields/>
 					</register>
 					<register>
 						<name>cpu_clk_gate</name>


### PR DESCRIPTION
SVDConv treats this as an error with `--strict` enabled:
```
*** ERROR M211: soc602_reg.svd (Line 18415)                                                               
  Ignoring Fields  (see previous message)
```
Note that the despite having it tell us to see the previous message, that message does not have more information despite it being the first message displayed.

Is the plan to continue SVD development in this repo or are we moving to the [Pine64](https://github.com/pine64/bl602-svd) repo when all PRs clear?